### PR TITLE
Implement core schema

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# ignore artifacts
+dist
+.turbo

--- a/examples/apollo-client/tsconfig.json
+++ b/examples/apollo-client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": false,
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ES2022",

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": false,
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ES2022",

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -1,0 +1,37 @@
+import { EventType } from './eventType';
+
+/**
+ * An event that can be emitted through the websocket
+ * @private This is an internal type and should not be used by consumers
+ */
+export interface Event {
+  /**
+   * A unique identifier for this span
+   */
+  id: string;
+
+  /**
+   * A unique identifier for this trace
+   * which may include 1 or more events
+   *
+   * @example
+   * A request and response event pair will have the same traceId
+   */
+  traceId: string;
+
+  /**
+   * A unique identifier used for grouping
+   * multiple events
+   */
+  parentId?: string;
+
+  /**
+   * UNIX Epoch time in seconds since 00:00:00 UTC on 1 January 1970
+   */
+  timestamp: number;
+
+  /**
+   * The type of event
+   */
+  type: EventType;
+}

--- a/packages/core/src/eventType.ts
+++ b/packages/core/src/eventType.ts
@@ -1,0 +1,9 @@
+export enum EventType {
+  HttpRequest = 'HttpRequest',
+  HttpResponse = 'HttpResponse',
+  GraphqlRequest = 'GraphqlRequest',
+  GraphqlResponse = 'GraphqlResponse',
+  // GraphqlResolver
+  // NodejsTelemetry
+  // others
+}

--- a/packages/core/src/graphql.ts
+++ b/packages/core/src/graphql.ts
@@ -1,0 +1,34 @@
+import { EventType } from './eventType';
+import { HttpRequestBase, HttpResponseBase } from './http';
+
+/**
+ * A Graphql Request
+ */
+export interface GraphqlRequest extends HttpRequestBase {
+  /**
+   * The full request query
+   */
+  query: string;
+
+  /**
+   * The parsed operation name
+   */
+  operationName?: string;
+
+  /**
+   * The query variables
+   */
+  variables?: Record<any, any>;
+
+  /**
+   * The event type
+   */
+  type: EventType.GraphqlRequest;
+}
+
+export interface GraphqlResponse extends HttpResponseBase {
+  /**
+   * The event type
+   */
+  type: EventType.GraphqlResponse;
+}

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,0 +1,81 @@
+import { Event } from './event';
+import { EventType } from './eventType';
+
+/**
+ * @private This is an internal type and should not be used by consumers
+ */
+interface HttpMessage extends Event {
+  /**
+   * The http request or response body
+   */
+  body?: string;
+
+  /**
+   * The normalized http headers (lowercase)
+   */
+  headers: Record<string, undefined | string | string[]>;
+}
+
+/**
+ * @private This is an internal type and should not be used by consumers
+ */
+export interface HttpRequestBase extends HttpMessage {
+  /**
+   * The host name
+   */
+  host: string;
+
+  /**
+   * The canonical HTTP version of the request
+   */
+  httpVersion: string;
+
+  /**
+   * The url path after the hostname
+   */
+  path: string | null;
+
+  /**
+   * The network port
+   */
+  port: number;
+
+  /**
+   * The HTTP method
+   */
+  method: 'GET' | 'POST';
+
+  /**
+   * The full url of the request
+   */
+  url: string;
+}
+
+/**
+ * @private This is an internal type and should not be used by consumers
+ */
+export interface HttpResponseBase extends HttpMessage {
+  /**
+   * The HTTP status code
+   */
+  statusCode: number;
+
+  /**
+   * The HTTP response text
+   */
+  statusMessage: string;
+}
+
+/**
+ * An HTTP Request
+ */
+export interface HttpRequest extends HttpRequestBase {
+  type: EventType.HttpRequest;
+}
+
+/**
+ * An HTTP Response
+ */
+export interface HttpResponse extends HttpResponseBase {
+  type: EventType.HttpResponse;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,3 @@
-export const one = 1;
+export { EventType } from './eventType';
+export { HttpRequest, HttpResponse } from './http';
+export { GraphqlRequest, GraphqlResponse } from './graphql';

--- a/packages/node/src/exporter.ts
+++ b/packages/node/src/exporter.ts
@@ -1,7 +1,10 @@
 /* eslint-disable no-console */
+import { EventType, type HttpRequest, type HttpResponse } from '@envy/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { ExportResult, ExportResultCode, hrTimeToMicroseconds } from '@opentelemetry/core';
 import WebSocket from 'ws';
+
+const IGNORE_HEADERS = ['host', 'traceparent'];
 
 export interface ExporterOptions {
   debug?: boolean;
@@ -17,8 +20,9 @@ export class WebsocketSpanExporter implements SpanExporter {
 
   constructor(private options: ExporterOptions) {
     // TODO: validate options aggressively
-
     this._ws = new WebSocket(options.socket);
+
+    // TODO: automatic reconnection
     this._ws.on('error', error => console.error('@envy/node websocket', { error, socket: options.socket }));
   }
 
@@ -51,20 +55,70 @@ export class WebsocketSpanExporter implements SpanExporter {
    * @param span
    */
   private _exportInfo(span: ReadableSpan) {
-    return {
-      traceId: span.spanContext().traceId,
-      parentId: span.parentSpanId,
-      traceState: span.spanContext().traceState?.serialize(),
-      name: span.name,
-      id: span.spanContext().spanId,
-      kind: span.kind,
+    // HACK: for now, we are going to emit the request and response
+    // together until we swap out opentelem
+
+    const id = span.spanContext().spanId;
+    const parentId = span.parentSpanId;
+    const traceId = span.spanContext().traceId;
+
+    const request: HttpRequest = {
+      id,
+      traceId,
+      parentId,
       timestamp: hrTimeToMicroseconds(span.startTime),
-      duration: hrTimeToMicroseconds(span.duration),
-      attributes: span.attributes,
-      status: span.status,
-      events: span.events,
-      links: span.links,
+      headers: this._parseHeaders(span.attributes, 'request'),
+      host: span.attributes['http.request.header.host'] as string,
+      httpVersion: span.attributes['http.flavor'] as string,
+      method: span.attributes['http.method'] as HttpRequest['method'],
+      path: span.attributes['http.target'] as string,
+      port: Number(span.attributes['net.peer.port']),
+      type: EventType.HttpRequest,
+      url: span.attributes['http.url'] as string,
+      body: span.attributes['http.request.body'] as string,
     };
+    this._sendEvent(request);
+
+    const response: HttpResponse = {
+      id: id + '1', // HACK: lol, temp abuse this span id
+      traceId,
+      parentId,
+      timestamp: hrTimeToMicroseconds(span.startTime) + hrTimeToMicroseconds(span.duration),
+      headers: this._parseHeaders(span.attributes, 'response'),
+      statusCode: Number(span.attributes['http.status_code']),
+      statusMessage: span.attributes['http.status_text'] as string,
+      type: EventType.HttpResponse,
+      body: span.attributes['http.response.body'] as string,
+    };
+    this._sendEvent(response);
+  }
+
+  /**
+   * Parse attributes for available headers
+   */
+  private _parseHeaders(attrs: Record<string, any>, type: 'request' | 'response') {
+    const headers: HttpRequest['headers'] = {};
+    const prefix = `http.${type}.header.`;
+    for (const key in attrs) {
+      if (key.startsWith(prefix) && !IGNORE_HEADERS.includes(key)) {
+        headers[key.replace(prefix, '')] = attrs[key];
+      }
+    }
+    return headers;
+  }
+
+  /**
+   * Sends the data to the websocket
+   * @param data
+   */
+  private _sendEvent(data: any) {
+    if (this.options.debug) {
+      console.dir(data, { depth: 3 });
+    }
+
+    // INFO: nested under "event" so we can send different
+    // types of messages to the server
+    this._ws.send(JSON.stringify(data));
   }
 
   /**
@@ -74,13 +128,7 @@ export class WebsocketSpanExporter implements SpanExporter {
    */
   private _sendSpans(spans: ReadableSpan[], done?: (result: ExportResult) => void): void {
     for (const span of spans) {
-      const formattedInfo = this._exportInfo(span);
-
-      if (this.options.debug) {
-        console.dir(formattedInfo, { depth: 3 });
-      }
-
-      this._ws.send(JSON.stringify(formattedInfo));
+      this._exportInfo(span);
     }
     if (done) {
       return done({ code: ExportResultCode.SUCCESS });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "esModuleInterop": true,
     "preserveConstEnums": true,
   }


### PR DESCRIPTION
Implements the core schema and splits the request and response into two segments. Currently, the request and response will only be emitted once the request is complete, a later PR will correct that.

Events have their own unique `id` property and use the `traceId` as a correlation mechanism. Multiple events can be grouped/nested under the `parentId` (future use cases).

Consumers can use the `type` field to determine how to handle the event.

### Request Event Schema
```
{
  id: '0e5792ca8d0fbe48',
  traceId: '33f1696170854d9c92f2bba34781e34b',
  parentId: undefined,
  timestamp: 1694542873616000,
  headers: {
    authorization: [ 'Bearer 12345' ],
    accept: [ '*/*' ],
    'user-agent': [ 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)' ],
    'accept-encoding': [ 'gzip,deflate' ],
    host: 'api.quotable.io'
  },
  host: 'api.quotable.io',
  httpVersion: '1.1',
  method: 'GET',
  path: '/quotes/random',
  port: 443,
  type: 'HttpRequest',
  url: 'https://api.quotable.io/quotes/random',
  body: undefined
}
```

### Response Event Schema
```
{
  id: '0e5792ca8d0fbe481',
  traceId: '33f1696170854d9c92f2bba34781e34b',
  parentId: undefined,
  timestamp: 1694542873768571.8,
  headers: {
    server: 'Cowboy',
    connection: 'close',
    'x-powered-by': 'Express',
    'access-control-allow-origin': '*',
    'ratelimit-limit': '220',
    'ratelimit-remaining': '219',
    'ratelimit-reset': '39',
    'content-type': 'application/json; charset=utf-8',
    'content-length': '251',
    etag: 'W/"fb-VzSyn5pMv3Jz4uaGW3WRX9BUups"',
    date: 'Tue, 12 Sep 2023 18:21:13 GMT',
    via: '1.1 vegur'
  },
  statusCode: 200,
  statusMessage: 'OK',
  type: 'HttpResponse',
  body: '[{"_id":"2qpi1ZKL9Ko","author":"Albert Einstein","content":"Perfection of means and confusion of ends seems to characterize our age.","tags":["Humorous"],"authorSlug":"albert-einstein","length":72,"dateAdded":"2023-04-06","dateModified":"2023-04-14"}]'
}
```