### PR TITLE
Wire up Envy and Epress

### DIFF
--- a/examples/apollo/package.json
+++ b/examples/apollo/package.json
@@ -16,7 +16,8 @@
     "@apollo/server": "^4.9.3",
     "apollo-utilities": "^1.3.4",
     "graphql": "^16.8.0",
-    "node-fetch": "2"
+    "node-fetch": "2",
+    "@envy/node": "*"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/examples/apollo/src/index.ts
+++ b/examples/apollo/src/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/order
-import { enableTracing } from '../../../packages/node/src';
+import { enableTracing } from '@envy/node';
 enableTracing({ debug: true, serviceName: 'examples/apollo' });
 
 import { ApolloServer } from '@apollo/server';

--- a/examples/express/app.ts
+++ b/examples/express/app.ts
@@ -1,4 +1,8 @@
+// eslint-disable-next-line import/order
+import { enableTracing } from '@envy/node';
+enableTracing({ debug: true, serviceName: 'examples/express' });
 import express from 'express';
+import fetch from 'node-fetch';
 
 const app = express();
 const port = 4000;

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "@envy/node": "*"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,7 +2,8 @@
   "name": "@envy/node",
   "version": "1.0.0",
   "description": "Node.js Network & Telemetry Viewer",
-  "main": "dist/index.js",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "repository": "https://github.com/FormidableLabs/envy.git",
   "license": "MIT",
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,8 +2,7 @@
   "name": "@envy/node",
   "version": "1.0.0",
   "description": "Node.js Network & Telemetry Viewer",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "dist/index.js",
   "repository": "https://github.com/FormidableLabs/envy.git",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## PR Summary
Connect `envy` to the example `express` app.  Also updated the `@envy/node` to allow for internal package imports into the example apps.