### PR TITLE
Added `web` sender and wired up to `example/apollo-client`

### DIFF
--- a/examples/apollo-client/package.json
+++ b/examples/apollo-client/package.json
@@ -5,9 +5,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start": "parcel ./src/index.html --port 4001"
+    "start": "parcel ./src/index.html --port 4001 --no-cache"
   },
   "dependencies": {
+    "@envy/web": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "urql": "^4.0.5"

--- a/examples/apollo-client/src/components/Sanity.tsx
+++ b/examples/apollo-client/src/components/Sanity.tsx
@@ -26,7 +26,7 @@ export default function Sanity() {
                   <div className="flex flex-col gap-2">
                     {category.products.map((product: any) => {
                       return product.variants.map((variant: any) => (
-                        <div className="flex flex-row justify-between ml-4 mr-12">
+                        <div key={variant.id} className="flex flex-row justify-between ml-4 mr-12">
                           <div>{variant.name}</div>
                           <div>${variant.price.toFixed(2)}</div>
                         </div>

--- a/examples/apollo-client/src/index.js
+++ b/examples/apollo-client/src/index.js
@@ -1,10 +1,11 @@
 import { enableTracing } from '@envy/web';
 import { createRoot } from 'react-dom/client';
 
-enableTracing({ serviceName: 'examples/apollo', debug: true, port: 9999 });
-
 import { App } from './App';
 
 const container = document.getElementById('app');
 const root = createRoot(container);
-root.render(<App />);
+
+enableTracing({ serviceName: 'examples/apollo-client', debug: true, port: 9999 }).then(() => {
+  root.render(<App />);
+});

--- a/examples/apollo-client/src/index.js
+++ b/examples/apollo-client/src/index.js
@@ -1,4 +1,7 @@
+import { enableTracing } from '@envy/web';
 import { createRoot } from 'react-dom/client';
+
+enableTracing({ serviceName: 'examples/apollo', debug: true, port: 9999 });
 
 import { App } from './App';
 

--- a/packages/browser/src/components/TraceDetail.tsx
+++ b/packages/browser/src/components/TraceDetail.tsx
@@ -42,8 +42,18 @@ export default function TraceDetail({ className }: DetailProps) {
   const { getSelectedTrace, clearSelectedTrace } = useApplication();
   const trace = getSelectedTrace();
 
-  const { timestamp, method, host, url, requestHeaders, statusCode, statusMessage, responseHeaders, duration } =
-    trace || {};
+  const {
+    serviceName,
+    timestamp,
+    method,
+    host,
+    url,
+    requestHeaders,
+    statusCode,
+    statusMessage,
+    responseHeaders,
+    duration,
+  } = trace || {};
   const responseComplete = duration !== undefined && statusCode !== undefined;
 
   const updateTimer = useCallback(() => {
@@ -110,6 +120,9 @@ export default function TraceDetail({ className }: DetailProps) {
                 )}
               </span>
               <span className="block text-opacity-70 text-black">{url}</span>
+            </div>
+            <div className="mt-4">
+              Sent from <span className="font-bold">{serviceName}</span>
             </div>
           </div>
         </div>

--- a/packages/browser/src/components/TraceDetail.tsx
+++ b/packages/browser/src/components/TraceDetail.tsx
@@ -22,7 +22,8 @@ type DetailProps = React.HTMLAttributes<HTMLElement>;
 function CodeDisplay({ contentType, children }: CodeDisplayProps) {
   if (!children) return null;
 
-  const isJson = contentType?.includes('application/json');
+  const isJson =
+    contentType?.includes('application/json') || contentType?.includes('application/graphql-response+json');
   const isXml = contentType?.includes('application/xml');
 
   return (

--- a/packages/browser/src/components/TraceList.tsx
+++ b/packages/browser/src/components/TraceList.tsx
@@ -1,4 +1,4 @@
-import { HiOutlineEmojiSad } from 'react-icons/hi';
+import { HiOutlineChartBar, HiOutlineEmojiSad, HiOutlineLightningBolt } from 'react-icons/hi';
 
 import { Loading } from '@/components/ui';
 import useApplication from '@/hooks/useApplication';
@@ -65,20 +65,17 @@ export default function TraceList({ className }: TraceListProps) {
     ['Time', getRequestDuration, 'w-[50px] md:w-[100px] text-center', () => ''],
   ];
 
+  const [Icon, message] = connected
+    ? [HiOutlineLightningBolt, `Connected to ws://localhost:${port}...`]
+    : connecting
+    ? [HiOutlineChartBar, 'Connecting...']
+    : [HiOutlineEmojiSad, 'Unable to connect'];
+
   return (
     <div className={`h-full flex flex-col overflow-y-scroll bg-slate-300 ${className}`}>
       {data.length === 0 ? (
-        <div className="flex flex-none h-full justify-center items-center text-3xl md:text-6xl text-slate-400">
-          {connected ? (
-            `Server established on ws://localhost:${port} - waiting for data...`
-          ) : connecting ? (
-            'connecting...'
-          ) : (
-            <span className="flex items-center gap-2">
-              <HiOutlineEmojiSad className="translate-y-[0.1em] w-8 h-8 md:w-16 md:h-16" />
-              <span>unable to connect</span>
-            </span>
-          )}
+        <div className="flex flex-none h-full justify-center items-center text-3xl text-slate-400">
+          <Icon className="translate-y-[0.1em] w-8 h-8 mr-2" /> <span>{message}</span>
         </div>
       ) : (
         <div className="table table-fixed w-full relative">

--- a/packages/browser/src/model/CollectorClient.ts
+++ b/packages/browser/src/model/CollectorClient.ts
@@ -13,8 +13,6 @@ export default class CollectorClient {
 
   private _connected: boolean = true;
   private _connecting: boolean = false;
-  private _shouldRetry: boolean = true;
-  private _retryCount: number = 0;
   private _traces: Traces = new Map();
   private _changeHandler?: () => void;
 
@@ -50,7 +48,6 @@ export default class CollectorClient {
     socket.onopen = () => {
       this._connecting = false;
       this._connected = true;
-      this._retryCount = 0;
       this._signalChange();
     };
 

--- a/packages/browser/src/model/CollectorClient.ts
+++ b/packages/browser/src/model/CollectorClient.ts
@@ -1,4 +1,4 @@
-import { Event, EventType, HttpRequest } from '@envy/core';
+import { DEFAULT_WEB_SOCKET_PORT, Event, EventType, HttpRequest } from '@envy/core';
 
 import { Traces } from '@/types';
 import { safeParseJson } from '@/utils';
@@ -44,7 +44,8 @@ export default class CollectorClient {
   }
 
   private _connect() {
-    const socket = new WebSocket(`ws://localhost:${this._port}/viewer`);
+    const port = this._port ?? DEFAULT_WEB_SOCKET_PORT;
+    const socket = new WebSocket(`ws://localhost:${port}/viewer`);
 
     socket.onopen = () => {
       this._connecting = false;
@@ -57,15 +58,6 @@ export default class CollectorClient {
       this._connected = false;
       this._connecting = true;
       this._signalChange();
-      this._retryCount += 1;
-      if (this._shouldRetry && this._retryCount < 3) {
-        // TODO: implement incremental back-off?
-        setTimeout(this._connect, 3000);
-      } else {
-        this._shouldRetry = false;
-        this._connecting = false;
-        this._signalChange();
-      }
     };
 
     socket.onmessage = ({ data }) => {

--- a/packages/browser/src/model/mockData.ts
+++ b/packages/browser/src/model/mockData.ts
@@ -14,12 +14,11 @@ function requestData(
   host: Trace['host'],
   port: Trace['port'],
   path: Trace['path'],
-): Pick<Trace, 'httpVersion' | 'method' | 'host' | 'port' | 'path' | 'url'> {
+): Pick<Trace, 'method' | 'host' | 'port' | 'path' | 'url'> {
   const protocol = port === 433 ? 'https://' : 'http://';
   const hostString = port === 80 || port === 443 ? `${host}` : `${host}:${port.toString()}`;
 
   return {
-    httpVersion: '1.1',
     method,
     host,
     port,
@@ -47,6 +46,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     responseHeaders: {
@@ -128,6 +128,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     responseHeaders: {
@@ -158,6 +159,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: 404,
     statusMessage: 'Not found',
     responseHeaders: {
@@ -191,6 +193,7 @@ const mockTraces: Trace[] = [
       lastName: 'Bear',
     }),
     // ---------
+    httpVersion: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     responseHeaders: {
@@ -205,7 +208,6 @@ const mockTraces: Trace[] = [
       'connection': 'keep-alive',
       'keep-alive': 'timeout=5',
     },
-    httpVersion: '1.1',
     responseBody: JSON.stringify({
       id: '4',
     }),
@@ -239,6 +241,7 @@ const mockTraces: Trace[] = [
       },
     }),
     // ---------
+    httpVersion: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     responseHeaders: {
@@ -276,6 +279,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: 500,
     statusMessage: 'Internal Server Error',
     responseHeaders: {
@@ -303,6 +307,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     responseHeaders: {
@@ -330,6 +335,7 @@ const mockTraces: Trace[] = [
     },
     requestBody: undefined,
     // ---------
+    httpVersion: '1.1',
     statusCode: undefined,
     statusMessage: undefined,
     responseHeaders: undefined,

--- a/packages/browser/src/model/mockData.ts
+++ b/packages/browser/src/model/mockData.ts
@@ -33,6 +33,7 @@ const mockTraces: Trace[] = [
     id: '1',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(0),
     ...requestData('GET', 'auth.restserver.com', 443, '/auth?client=mock_client'),
     requestHeaders: {
@@ -71,6 +72,7 @@ const mockTraces: Trace[] = [
     id: '2',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'web',
     timestamp: elapseTime(0.1),
     ...requestData('POST', 'localhost', 3000, '/api/graphql'),
     requestHeaders: {
@@ -119,6 +121,7 @@ const mockTraces: Trace[] = [
     id: '3',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(1.2),
     ...requestData('GET', 'data.restserver.com', 443, '/features'),
     requestHeaders: {
@@ -150,6 +153,7 @@ const mockTraces: Trace[] = [
     id: '4',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(3.1),
     ...requestData('GET', 'data.restserver.com', 443, '/countries?start=0&count=20'),
     requestHeaders: {
@@ -178,6 +182,7 @@ const mockTraces: Trace[] = [
     id: '5',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(16.3),
     ...requestData('POST', 'data.restserver.com', 443, '/people'),
     requestHeaders: {
@@ -219,6 +224,7 @@ const mockTraces: Trace[] = [
     id: '6',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'web',
     timestamp: elapseTime(0.1),
     ...requestData('POST', 'localhost', 3000, '/api/graphql'),
     requestHeaders: {
@@ -270,6 +276,7 @@ const mockTraces: Trace[] = [
     id: '7',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(3.14),
     ...requestData('GET', 'data.restserver.com', 433, '/movies?start=0&count=20'),
     requestHeaders: {
@@ -298,6 +305,7 @@ const mockTraces: Trace[] = [
     id: '8',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(3.14),
     ...requestData('GET', 'hits.webstats.com', 433, '/?apikey=c82e66bd-4d5b-4bb7-b439-896936c94eb2'),
     requestHeaders: {
@@ -326,6 +334,7 @@ const mockTraces: Trace[] = [
     id: '9',
     parentId: undefined,
     type: EventType.HttpRequest,
+    serviceName: 'gql',
     timestamp: elapseTime(0.4),
     ...requestData('GET', 'data.restserver.com', 433, '/features'),
     requestHeaders: {

--- a/packages/browser/src/scripts/startCollector.cjs
+++ b/packages/browser/src/scripts/startCollector.cjs
@@ -18,21 +18,18 @@ wss.on('listening', () => {
 });
 
 wss.on('connection', (ws, request) => {
-  if (request.url === '/viewer' && !viewer) {
+  if (request.url === '/viewer') {
     log(chalk.green('✅ Envy viewer client connected'));
     viewer = ws;
   }
 
-  if (request.url === '/node' && !viewer) {
+  if (request.startsWith === '/node') {
     log(chalk.green('✅ Envy node sender connected'));
   }
 
-  ws.on('close', () => {
-    if (viewer !== null) {
-      log(chalk.red('❌ Envy viewer client disconnected'));
-      viewer = null;
-    }
-  });
+  if (request.startsWith === '/web') {
+    log(chalk.green('✅ Envy web sender connected'));
+  }
 
   ws.on('message', data => {
     if (!viewer || viewer.readyState !== WebSocket.OPEN) {

--- a/packages/browser/src/systems/GraphQL.tsx
+++ b/packages/browser/src/systems/GraphQL.tsx
@@ -21,7 +21,7 @@ export default class GraphQL implements System<GraphQLData> {
   name = 'GraphQL';
 
   isMatch(trace: Trace) {
-    return trace.path === '/api/graphql';
+    return trace.path?.endsWith('/graphql') ?? false;
   }
 
   getData(trace: Trace) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@envy/web",
+  "version": "0.1.0",
+  "description": "Node.js Network & Telemetry Viewer",
+  "main": "dist/index.js",
+  "repository": "https://github.com/FormidableLabs/envy.git",
+  "license": "MIT",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@envy/core": "0.2.0"
+  }
+}

--- a/packages/web/src/http.ts
+++ b/packages/web/src/http.ts
@@ -1,0 +1,64 @@
+import { EventType, HttpRequest } from '@envy/core';
+
+function formatHeaders(headers: HeadersInit | Headers | undefined): HttpRequest['requestHeaders'] {
+  if (headers) {
+    if (Array.isArray(headers)) {
+      return headers.reduce<HttpRequest['requestHeaders']>((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {});
+    } else if (headers instanceof Headers) {
+      return Object.fromEntries(headers.entries());
+    } else {
+      return headers;
+    }
+  }
+
+  return {};
+}
+
+export function fetchRequestToEvent(
+  timestamp: number,
+  id: string,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): HttpRequest {
+  let url: URL;
+  if (typeof input === 'string') {
+    url = new URL(input);
+  } else if (input instanceof Request) {
+    url = new URL(input.url);
+  } else {
+    url = input;
+  }
+
+  return {
+    id,
+    parentId: undefined,
+    timestamp,
+    type: EventType.HttpRequest,
+    method: (init?.method ?? 'GET') as HttpRequest['method'],
+    host: url.host,
+    port: parseInt(url.port, 10),
+    path: url.pathname,
+    url: url.toString(),
+    requestHeaders: formatHeaders(init?.headers),
+    requestBody: init?.body?.toString() ?? undefined,
+  };
+}
+
+export async function fetchResponseToEvent(
+  timestamp: number,
+  req: HttpRequest,
+  response: Response,
+): Promise<HttpRequest> {
+  return {
+    ...req,
+    httpVersion: response.type,
+    statusCode: response.status,
+    statusMessage: response.statusText,
+    responseHeaders: formatHeaders(response.headers),
+    responseBody: await response.text(),
+    duration: timestamp - req.timestamp,
+  };
+}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,1 @@
+export * from './tracing';

--- a/packages/web/src/log.ts
+++ b/packages/web/src/log.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-console */
+
+const { name } = require('../package.json');
+
+export default {
+  info: (msg: string, ...args: unknown[]) => console.log(`✅ %c${name} ${msg}`, 'color: green', ...args),
+  warn: (msg: string, ...args: unknown[]) => console.log(`🚸 %c${name} ${msg}`, 'color: yellow', ...args),
+  error: (msg: string, ...args: unknown[]) => console.log(`❌ %c${name} ${msg}`, 'color: red', ...args),
+  debug: (msg: string, ...args: unknown[]) => console.log(`🔧 %c$${name} ${msg}`, 'color: cyan', ...args),
+};

--- a/packages/web/src/nanoid.ts
+++ b/packages/web/src/nanoid.ts
@@ -1,0 +1,8 @@
+export const nanoid = (t = 21) =>
+  crypto
+    .getRandomValues(new Uint8Array(t))
+    .reduce(
+      (t: any, e: any) =>
+        (t += (e &= 63) < 36 ? e.toString(36) : e < 62 ? (e - 26).toString(36).toUpperCase() : e < 63 ? '_' : '-'),
+      '',
+    );

--- a/packages/web/src/options.ts
+++ b/packages/web/src/options.ts
@@ -1,0 +1,4 @@
+export interface Options {
+  serviceName: string;
+  debug?: boolean;
+}

--- a/packages/web/src/tracing.ts
+++ b/packages/web/src/tracing.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_WEB_SOCKET_PORT } from '@envy/core';
+
+import { fetchRequestToEvent, fetchResponseToEvent } from './http';
+import log from './log';
+import { Options } from './options';
+
+export interface TracingOptions extends Options {
+  port?: number;
+}
+
+export function enableTracing(options: TracingOptions) {
+  if (typeof window === 'undefined') {
+    log.error('Attempted to use @envy/web in a non-browser environment');
+    return;
+  }
+
+  if (options.debug) log.info('Starting in debug mode');
+
+  const wsUri = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/web/${options.serviceName}`;
+  const ws = new WebSocket(wsUri);
+  ws.onopen = () => {
+    if (options.debug) log.info(`Connected to ${wsUri}`);
+
+    const { fetch: originalFetch } = window;
+
+    window.fetch = async (...args) => {
+      // TODO: better unique id
+      const tsReq = Date.now();
+      const id = `${tsReq}`;
+
+      const reqEvent = fetchRequestToEvent(tsReq, id, ...args);
+      ws.send(JSON.stringify(reqEvent));
+
+      const response = await originalFetch(...args);
+      const tsRes = Date.now();
+      const responseClone = response.clone();
+      const resEvent = await fetchResponseToEvent(tsRes, reqEvent, responseClone);
+      ws.send(JSON.stringify(resEvent));
+
+      return response;
+    };
+  };
+}

--- a/packages/web/src/tracing.ts
+++ b/packages/web/src/tracing.ts
@@ -1,43 +1,81 @@
-import { DEFAULT_WEB_SOCKET_PORT } from '@envy/core';
+import { DEFAULT_WEB_SOCKET_PORT, HttpRequest } from '@envy/core';
 
 import { fetchRequestToEvent, fetchResponseToEvent } from './http';
 import log from './log';
+import { nanoid } from './nanoid';
 import { Options } from './options';
 
 export interface TracingOptions extends Options {
   port?: number;
 }
 
-export function enableTracing(options: TracingOptions) {
+const initialTraces: Record<string, HttpRequest> = {};
+
+export async function enableTracing(options: TracingOptions): Promise<void> {
   if (typeof window === 'undefined') {
     log.error('Attempted to use @envy/web in a non-browser environment');
-    return;
+    return Promise.resolve();
   }
 
-  if (options.debug) log.info('Starting in debug mode');
+  return new Promise(resolve => {
+    if (options.debug) log.info('Starting in debug mode');
 
-  const wsUri = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/web/${options.serviceName}`;
-  const ws = new WebSocket(wsUri);
-  ws.onopen = () => {
-    if (options.debug) log.info(`Connected to ${wsUri}`);
+    const port = options.port ?? DEFAULT_WEB_SOCKET_PORT;
+    const serviceName = options.serviceName;
+
+    const wsUri = `ws://127.0.0.1:${port}/web/${serviceName}`;
+    const ws = new WebSocket(wsUri);
 
     const { fetch: originalFetch } = window;
-
     window.fetch = async (...args) => {
-      // TODO: better unique id
       const tsReq = Date.now();
-      const id = `${tsReq}`;
+      const id = nanoid();
 
       const reqEvent = fetchRequestToEvent(tsReq, id, ...args);
-      ws.send(JSON.stringify(reqEvent));
+      if (ws.readyState === ws.OPEN) {
+        ws.send(
+          JSON.stringify({
+            ...reqEvent,
+            serviceName,
+          }),
+        );
+      } else {
+        initialTraces[id] = reqEvent;
+      }
 
       const response = await originalFetch(...args);
       const tsRes = Date.now();
       const responseClone = response.clone();
       const resEvent = await fetchResponseToEvent(tsRes, reqEvent, responseClone);
-      ws.send(JSON.stringify(resEvent));
+
+      if (ws.readyState === ws.OPEN) {
+        ws.send(
+          JSON.stringify({
+            ...resEvent,
+            serviceName,
+          }),
+        );
+      } else {
+        initialTraces[id] = resEvent;
+      }
 
       return response;
     };
-  };
+
+    ws.onopen = () => {
+      if (options.debug) log.info(`Connected to ${wsUri}`);
+
+      // flush any request traces captured prior to the socket being open
+      for (const trace of Object.entries(initialTraces)) {
+        ws.send(
+          JSON.stringify({
+            ...trace,
+            serviceName,
+          }),
+        );
+      }
+
+      resolve();
+    };
+  });
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.ts"],
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Adds `packages/web` which you can use to connect your client web application to Envy, ideally before mounting the app (so that initial requests are captured).
```tsx
// index.tsx

import { enableTracing } from '@envy/web';
import { createRoot } from 'react-dom/client';
import { App } from './App';

const container = document.getElementById('app');
const root = createRoot(container);

// connect to Envy via `@envy/web` and mount the app
enableTracing({ serviceName: 'my-web-app', port: 9999 }).then(() => {
  root.render(<App />);
});
```
- Adds support for web senders in the collector
- Removes the `on('close')` listener in the collector, since refreshing the browser would disconnect the `@envy/browser` viewer
- Displays the service name of the application which sent the trace data in the detail view

## Screenshots

![image](https://github.com/FormidableLabs/envy/assets/17857833/2a013076-9a39-424f-8b8d-6073b5120742)

![image](https://github.com/FormidableLabs/envy/assets/17857833/7a31422b-dd3b-4f28-8df4-65621c36efb1)

![image](https://github.com/FormidableLabs/envy/assets/17857833/3eab288f-b094-453c-b4e5-7ae0fb94cba8)

## How to test
- You know the drill by now...
- `yarn workspace @envy/browser start` in one terminal, then open `http://localhost:9998`
- `yarn example:apollo` in another, then open `http://localhost:4001`
- You should see four GQL traces in the browser UI (coming from `examples/apollo-client`) as well as five other traces (coming from `examples/apollo`)
- Click the orange refresh buttons in the example app and you'll see both the GQL request (coming from `apollo-client`) and the upstream requests (coming from `apollo`)