### PR TITLE
Ensure browser viewer only connects to collector once

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Import the tracing package into your applications entry point. These lines must 
 
 ```
 import { enableTracing } from '@envy/node';
-enableTracing();
+enableTracing({ serviceName: 'name-of-your-app' });
 ```
 
 Start your application and then launch the `@envy/browser` in a new terminal to start viewing network traces

--- a/packages/browser/src/components/DebugToolbar.tsx
+++ b/packages/browser/src/components/DebugToolbar.tsx
@@ -10,7 +10,7 @@ export default function DebugToolbar() {
 
   const addMockData = useCallback(() => {
     for (const trace of mockData) {
-      collector.addHttpRequest(trace);
+      collector?.addHttpRequest(trace);
     }
   }, [collector]);
 

--- a/packages/browser/src/components/TraceList.tsx
+++ b/packages/browser/src/components/TraceList.tsx
@@ -1,4 +1,4 @@
-import { HiOutlineChartBar, HiOutlineEmojiSad, HiOutlineLightningBolt } from 'react-icons/hi';
+import { HiOutlineEmojiSad, HiOutlineLightningBolt, HiStatusOnline } from 'react-icons/hi';
 
 import { Loading } from '@/components/ui';
 import useApplication from '@/hooks/useApplication';
@@ -66,16 +66,16 @@ export default function TraceList({ className }: TraceListProps) {
   ];
 
   const [Icon, message] = connected
-    ? [HiOutlineLightningBolt, `Connected to ws://localhost:${port}...`]
+    ? [HiStatusOnline, `Connected to ws://localhost:${port}/ ...`]
     : connecting
-    ? [HiOutlineChartBar, 'Connecting...']
+    ? [HiOutlineLightningBolt, 'Connecting...']
     : [HiOutlineEmojiSad, 'Unable to connect'];
 
   return (
     <div className={`h-full flex flex-col overflow-y-scroll bg-slate-300 ${className}`}>
       {data.length === 0 ? (
         <div className="flex flex-none h-full justify-center items-center text-3xl text-slate-400">
-          <Icon className="translate-y-[0.1em] w-8 h-8 mr-2" /> <span>{message}</span>
+          <Icon className="translate-y-[0.05em] w-8 h-8 mr-2" /> <span>{message}</span>
         </div>
       ) : (
         <div className="table table-fixed w-full relative">

--- a/packages/browser/src/hooks/useApplication.ts
+++ b/packages/browser/src/hooks/useApplication.ts
@@ -4,7 +4,7 @@ import CollectorClient from '@/model/CollectorClient';
 import { Trace, Traces } from '@/types';
 
 export type ApplicationContextData = {
-  collector: CollectorClient;
+  collector: CollectorClient | undefined;
   port: number;
   connecting: boolean;
   connected: boolean;

--- a/packages/browser/src/model/CollectorClient.ts
+++ b/packages/browser/src/model/CollectorClient.ts
@@ -51,12 +51,6 @@ export default class CollectorClient {
       this._signalChange();
     };
 
-    socket.onclose = () => {
-      this._connected = false;
-      this._connecting = true;
-      this._signalChange();
-    };
-
     socket.onmessage = ({ data }) => {
       const payload = safeParseJson<Event>(data.toString());
       switch (payload?.type) {

--- a/packages/browser/src/scripts/startCollector.cjs
+++ b/packages/browser/src/scripts/startCollector.cjs
@@ -18,22 +18,21 @@ wss.on('listening', () => {
 });
 
 wss.on('connection', (ws, request) => {
-  if (request.url === '/viewer') {
-    log(chalk.green('✅ Envy viewer client connected'));
+  const identifier = request.url.startsWith('/') ? request.url.substring(1) : request.url;
+  const idxFirstSlash = identifier.indexOf('/');
+  const [namespace, serviceName] =
+    idxFirstSlash === -1 ? [identifier, ''] : [identifier.slice(0, idxFirstSlash), identifier.slice(idxFirstSlash + 1)];
+
+  if (namespace === 'viewer') {
     viewer = ws;
   }
 
-  if (request.startsWith === '/node') {
-    log(chalk.green('✅ Envy node sender connected'));
-  }
-
-  if (request.startsWith === '/web') {
-    log(chalk.green('✅ Envy web sender connected'));
-  }
+  const serviceNameDetail = !!serviceName ? `: ${chalk.yellow(serviceName)}` : '';
+  log(chalk.green(`✅ Envy ${chalk.cyan(namespace)} connected${serviceNameDetail}`));
 
   ws.on('message', data => {
     if (!viewer || viewer.readyState !== WebSocket.OPEN) {
-      handleError('No viewers registered');
+      handleError('No viewers connected');
       return;
     }
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,9 +1,10 @@
+import { DEFAULT_WEB_SOCKET_PORT } from '@envy/core';
 import WebSocket from 'ws';
 
 import log from './log';
+import { Options } from './options';
 
-export interface WebSocketClientOptions {
-  debug?: boolean;
+export interface WebSocketClientOptions extends Options {
   port?: number;
 }
 
@@ -15,7 +16,7 @@ export function WebSocketClient(options: WebSocketClientOptions) {
   let retryDelay = DEFAULT_RETRY_DELAY;
   let retryAttempts = 0;
 
-  const socket = `ws://127.0.0.1:${options.port ?? 9999}/node`;
+  const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/node/${options.serviceName}`;
 
   function connect() {
     ws = new WebSocket(socket);


### PR DESCRIPTION
## What does this PR do

- The browser UI viewer was creating two connections to `ws://127.0.0.1:9999/viewer` when the app was mounted
- This PR fixes this so that only one connection is made
- Console logging of connections has also been improved

## Screenshots

![image](https://github.com/FormidableLabs/envy/assets/17857833/8e38c469-ea0e-4d11-8a26-d1131724acbe)
