### PR TITLE
Fix timestamp and adjust custom detail location

### DIFF
--- a/packages/browser/src/components/TraceDetail.tsx
+++ b/packages/browser/src/components/TraceDetail.tsx
@@ -129,8 +129,6 @@ export default function TraceDetail({ className }: DetailProps) {
         </div>
       </div>
 
-      <SystemRequestDetailsComponent trace={trace} />
-
       <Section title="Request details">
         <Fields>
           <Field label="Sent">
@@ -144,6 +142,7 @@ export default function TraceDetail({ className }: DetailProps) {
           <QueryParams trace={trace} />
           <RequestHeaders trace={trace} />
         </Fields>
+        <SystemRequestDetailsComponent trace={trace} />
       </Section>
 
       <Section title="Response details">

--- a/packages/browser/src/components/ui/DateTime.tsx
+++ b/packages/browser/src/components/ui/DateTime.tsx
@@ -5,7 +5,8 @@ export type DateTimeProps = React.HTMLAttributes<HTMLElement> & {
 export default function DateTime({ time }: DateTimeProps) {
   if (time === undefined) return null;
 
-  const formattedTime = new Date(time).toISOString().replace('T', ' @ ').substring(0, 25);
+  const date = new Date(time);
+  const formattedTime = `${date.toLocaleDateString()} @ ${date.toLocaleTimeString()}`;
 
   return <>{formattedTime}</>;
 }

--- a/packages/browser/src/styles/base.css
+++ b/packages/browser/src/styles/base.css
@@ -8,6 +8,10 @@ main#root {
   @apply h-full;
 }
 
+hr {
+  @apply block border-0 border-b border-b-slate-300 h-0 pt-4 !mb-4;
+}
+
 ::-webkit-scrollbar {
   @apply bg-slate-500 w-3 h-3;
 }
@@ -235,13 +239,7 @@ main#root {
 }
 
 /* Hide the root expand/collapse icon */
-.react-json-view
-  > .pretty-json-container
-  > .object-content
-  > .object-key-val
-  > span
-  > span
-  > .icon-container {
+.react-json-view > .pretty-json-container > .object-content > .object-key-val > span > span > .icon-container {
   @apply !hidden;
 }
 

--- a/packages/browser/src/systems/GraphQL.tsx
+++ b/packages/browser/src/systems/GraphQL.tsx
@@ -70,11 +70,7 @@ export default class GraphQL implements System<GraphQLData> {
     );
   }
 
-  responseDetailComponent(trace: Trace) {
-    const { response } = this.getData(trace);
-    if (!response) return null;
-
-    const json = safeParseJson(response);
-    return <>{json.error && <Label label="Errors">ERRORS!</Label>}</>;
+  responseDetailComponent(_: Trace) {
+    return null;
   }
 }

--- a/packages/browser/src/systems/index.tsx
+++ b/packages/browser/src/systems/index.tsx
@@ -57,11 +57,20 @@ export function ListDataComponent({ trace }: SystemDetailProps): React.ReactNode
 
 export function SystemRequestDetailsComponent({ trace }: SystemDetailProps): React.ReactNode {
   const Component = callOrFallback<ReactNode | null>(trace, 'requestDetailComponent');
-
-  if (!Component) return null;
-  return <Section title="Request summary">{Component}</Section>;
+  return Component ? (
+    <>
+      <hr />
+      {Component}
+    </>
+  ) : null;
 }
 
 export function SystemResponseDetailsComponent({ trace }: SystemDetailProps): React.ReactNode {
-  return callOrFallback(trace, 'responseDetailComponent');
+  const Component = callOrFallback<ReactNode | null>(trace, 'responseDetailComponent');
+  return Component ? (
+    <>
+      <hr />
+      {Component}
+    </>
+  ) : null;
 }

--- a/packages/node/src/http.ts
+++ b/packages/node/src/http.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import https from 'https';
-import { performance } from 'perf_hooks';
 import { types as utilTypes } from 'util';
 
 import { EventType, HttpRequest, nanoid } from '@envy/core';
@@ -31,7 +30,7 @@ export const Http: Plugin = (_options, exporter) => {
     _wrap(module, 'request', (original: any) => {
       return function (this: any, ...args: http.ClientRequestArgs[]) {
         const id = nanoid();
-        const startTs = performance.now();
+        const startTs = Date.now();
 
         const request = original.apply(this, args) as http.ClientRequest;
         const write = request.write;
@@ -83,7 +82,7 @@ export const Http: Plugin = (_options, exporter) => {
           };
 
           const onRequestEnd = () => {
-            const endTs = performance.now();
+            const endTs = Date.now();
 
             const httpResponse: HttpRequest = {
               ...httpRequest,


### PR DESCRIPTION
## What does this PR do

- Fixes how sent & received timestamps are presented
- Updated `@envy/node` to send `Date.now()` instead of `performance.now()` (where the latter was ticks since the start of the process)
- Updated where custom request details components are rendered so that the layout is consistent for all systems