### PR TITLE
Fixed issue with trace data coming through as tuple

### DIFF
--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -24,7 +24,7 @@ export function WebSocketClient(options: WebSocketClientOptions) {
       log.info('client connected');
       retryDelay = DEFAULT_RETRY_DELAY;
 
-      for (const trace of Object.entries(initialTraces)) {
+      for (const trace of Object.values(initialTraces)) {
         ws.send(JSON.stringify(trace));
       }
     };
@@ -60,12 +60,6 @@ export function WebSocketClient(options: WebSocketClientOptions) {
 
   return {
     send: (data: Event) => {
-      // if (options.debug) {
-      //   if (data.url !== socket.replace('ws', 'http')) {
-      //     log.debug('sending', data);
-      //   }
-      // }
-
       try {
         if (ws.readyState === ws.OPEN) {
           ws.send(JSON.stringify(data));


### PR DESCRIPTION
## 🐛 What was the observed bug?

We'd sometimes see a trace row with no data, stuck in a "waiting" state:

![image](https://github.com/FormidableLabs/envy/assets/17857833/8f462e6d-268f-4233-8a24-9b2597f7a158)

## What was the cause?

Initial traces were being sent to the collector in tuple format, e.g.,
```
['123456', '{"id":"123456","timestamp":1695642906895, ... }']
```

...whereas they should always be just the serialised trace:
```
{"id":"123456","timestamp":1695642906895, ... }
```

This was a bug in the logic which buffers traces before the WS connection is made, and then flushes them through.  It was flushing the items from the buffer's `Map`, whereas it should just send the values from this map.