### PR TITLE
Fix startup script for windows

### DIFF
--- a/.changeset/chilly-birds-run.md
+++ b/.changeset/chilly-birds-run.md
@@ -1,0 +1,6 @@
+---
+'@envyjs/webui': patch
+'@envyjs/web': patch
+---
+
+Fix windows startup scripts

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -20,7 +20,7 @@
     "README.md"
   ],
   "scripts": {
-    "start": "NODE_ENV=development node ./src/scripts/start.cjs --dev",
+    "start": "cross-env NODE_ENV=development node ./src/scripts/start.cjs --dev",
     "test": "jest",
     "test:watch": "jest --watch --coverage",
     "test:coverage": "jest --coverage && open ./coverage/lcov-report/index.html",


### PR DESCRIPTION
Uses `cross-env` to ensure scripts run correctly regardless of OS.

Closes #77 