### PR TITLE
Add timing data to browser fetch

### DIFF
--- a/.changeset/breezy-gorillas-sparkle.md
+++ b/.changeset/breezy-gorillas-sparkle.md
@@ -1,5 +1,0 @@
----
-'@envyjs/web': minor
----
-
-Add timing data for web client requests

--- a/.changeset/breezy-gorillas-sparkle.md
+++ b/.changeset/breezy-gorillas-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/web': minor
+---
+
+Add timing data for web client requests

--- a/.changeset/happy-yaks-shake.md
+++ b/.changeset/happy-yaks-shake.md
@@ -1,0 +1,6 @@
+---
+'@envyjs/webui': minor
+'@envyjs/web': minor
+---
+
+Show timing data for web requests

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ enableTracing({ serviceName: 'your-website-name' }).then(() => {
 });
 ```
 
+#### Timing Data
+
+_Browsers prevent full timing data from being accessed from cross-origin requests unless the server responds with the [Timing-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin) header_.
+
 ## Contributing
 
 Please see the [Contributing guide](CONTRIBUTING.md).

--- a/examples/apollo/package.json
+++ b/examples/apollo/package.json
@@ -9,15 +9,17 @@
   },
   "dependencies": {
     "@apollo/server": "^4.9.3",
-    "@envyjs/webui": "*",
-    "@envyjs/node": "*",
     "@sanity/client": "^4.0.1",
     "apollo-utilities": "^1.3.4",
+    "cors": "2.8.5",
     "graphql": "^16.8.0",
     "groqd": "^0.15.9",
     "node-fetch": "2"
   },
   "devDependencies": {
+    "@envyjs/webui": "*",
+    "@envyjs/node": "*",
+    "@types/cors": "2.8.14",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }

--- a/examples/express/app.ts
+++ b/examples/express/app.ts
@@ -1,11 +1,16 @@
 // eslint-disable-next-line import/order
 import { enableTracing } from '@envyjs/node';
-enableTracing({ debug: true, serviceName: 'examples/express' });
-import express from 'express';
+enableTracing({ serviceName: 'examples/express' });
+import express, { NextFunction, Response } from 'express';
 import fetch from 'node-fetch';
 
 const app = express();
 const port = 4000;
+
+app.use((_, response: Response, next: NextFunction) => {
+  response.setHeader('Timing-Allow-Origin', '*');
+  next();
+});
 
 app.get('/api/cat-fact', async (_, response) => {
   const res = await fetch('https://cat-fact.herokuapp.com/facts');

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -60,6 +60,11 @@ export interface HttpRequest {
   statusMessage?: string;
 
   /**
+   * Returns true ff timing data is blocked by CORS
+   */
+  timingsBlockedByCors?: boolean;
+
+  /**
    * HAR formatted timing information
    *
    * http://www.softwareishard.com/blog/har-12-spec/#timings

--- a/packages/web/src/http.ts
+++ b/packages/web/src/http.ts
@@ -29,11 +29,14 @@ export const Http: Plugin = (_options, exporter) => {
     const endMark = marks.find(x => (x as PerformanceMark).detail.type === 'end');
 
     // find the timings that occured between the two marks
-    const time = performance
-      .getEntriesByName(reqEvent.http!.url)
-      .find(x => x.startTime >= startMark!.startTime && x.startTime <= endMark!.startTime) as
-      | PerformanceResourceTiming
-      | undefined;
+    let time: PerformanceResourceTiming | undefined;
+    if (startMark && endMark) {
+      time = performance
+        .getEntriesByName(reqEvent.http!.url)
+        .find(x => x.startTime >= startMark!.startTime && x.startTime <= endMark!.startTime) as
+        | PerformanceResourceTiming
+        | undefined;
+    }
 
     // calculate a fallback if we don't have timing data available
     const fallbackDuration = performance.now() - startTs;

--- a/packages/web/src/http.ts
+++ b/packages/web/src/http.ts
@@ -38,11 +38,16 @@ export const Http: Plugin = (_options, exporter) => {
         | undefined;
     }
 
-    // calculate a fallback if we don't have timing data available
-    const fallbackDuration = performance.now() - startTs;
+    // calculate the timing, or use a fallback if not available
     const { duration, timings } = calculateTiming(time);
-    resEvent.http!.duration = duration || fallbackDuration;
-    resEvent.http!.timings = timings;
+    if (duration) {
+      resEvent.http!.duration = duration;
+      resEvent.http!.timings = timings;
+    } else {
+      const fallbackDuration = performance.now() - startTs;
+      resEvent.http!.timingsBlockedByCors = true;
+      resEvent.http!.duration = fallbackDuration;
+    }
 
     // export the final request data which now includes response
     exporter.send(resEvent);

--- a/packages/web/src/performance.ts
+++ b/packages/web/src/performance.ts
@@ -1,0 +1,44 @@
+import { HttpRequest } from '@envyjs/core';
+
+/**
+ * Calculate timing data from performance API data
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming
+ */
+export function calculateTiming(time: PerformanceResourceTiming | undefined): {
+  duration?: number;
+  timings?: HttpRequest['timings'];
+} {
+  if (!time) return {};
+
+  const timings: HttpRequest['timings'] = {
+    blocked: time.fetchStart - time.startTime,
+    dns: -1,
+    connect: -1,
+    send: 0, // there is no data available for this in native fetch
+    wait: time.responseEnd - time.fetchStart,
+    receive: 0,
+    ssl: -1,
+  };
+
+  // Some data is not available if the resource is a cross-origin request
+  // and no Timing-Allow-Origin HTTP response header is used
+  //
+  // Check if we have this data available, and if we do, we can
+  // improve the timing data with it
+  if (time.requestStart !== 0) {
+    timings.dns = time.domainLookupEnd - time.domainLookupStart;
+    timings.connect = time.connectEnd - time.connectStart;
+
+    if (time.secureConnectionStart) {
+      timings.ssl = time.connectEnd - time.secureConnectionStart;
+    }
+
+    timings.wait = time.responseStart - time.requestStart;
+    timings.receive = time.responseEnd - time.responseStart;
+  }
+
+  return {
+    duration: time.duration,
+    timings,
+  };
+}

--- a/packages/web/src/performance.ts
+++ b/packages/web/src/performance.ts
@@ -8,33 +8,25 @@ export function calculateTiming(time: PerformanceResourceTiming | undefined): {
   duration?: number;
   timings?: HttpRequest['timings'];
 } {
-  if (!time) return {};
-
-  const timings: HttpRequest['timings'] = {
-    blocked: time.fetchStart - time.startTime,
-    dns: -1,
-    connect: -1,
-    send: 0, // there is no data available for this in native fetch
-    wait: time.responseEnd - time.fetchStart,
-    receive: 0,
-    ssl: -1,
-  };
-
   // Some data is not available if the resource is a cross-origin request
   // and no Timing-Allow-Origin HTTP response header is used
   //
   // Check if we have this data available, and if we do, we can
   // improve the timing data with it
-  if (time.requestStart !== 0) {
-    timings.dns = time.domainLookupEnd - time.domainLookupStart;
-    timings.connect = time.connectEnd - time.connectStart;
+  if (!time?.requestStart) return {};
 
-    if (time.secureConnectionStart) {
-      timings.ssl = time.connectEnd - time.secureConnectionStart;
-    }
+  const timings: HttpRequest['timings'] = {
+    blocked: time.fetchStart - time.startTime,
+    dns: time.domainLookupEnd - time.domainLookupStart,
+    connect: time.connectEnd - time.connectStart,
+    send: 0, // there is no data available for this in native fetch
+    wait: time.responseStart - time.requestStart,
+    receive: time.responseEnd - time.responseStart,
+    ssl: -1,
+  };
 
-    timings.wait = time.responseStart - time.requestStart;
-    timings.receive = time.responseEnd - time.responseStart;
+  if (time.secureConnectionStart) {
+    timings.ssl = time.connectEnd - time.secureConnectionStart;
   }
 
   return {

--- a/packages/webui/src/components/ui/TraceDetail.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.tsx
@@ -163,8 +163,8 @@ export default function TraceDetail({ className }: DetailProps) {
               <Field data-test-id="duration" label="Duration">
                 {numberFormat(duration)}ms
               </Field>
-              {!trace.http?.timings && trace.http?.statusCode !== 304 && (
-                <Field data-test-id="timings" label="Timings">
+              {trace.http?.timingsBlockedByCors && (
+                <Field data-test-id="timings-blocked" label="Timings">
                   <a
                     href="https://github.com/FormidableLabs/envy#web-client-application"
                     target="_blank"

--- a/packages/webui/src/components/ui/TraceDetail.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.tsx
@@ -163,6 +163,18 @@ export default function TraceDetail({ className }: DetailProps) {
               <Field data-test-id="duration" label="Duration">
                 {numberFormat(duration)}ms
               </Field>
+              {!trace.http?.timings && trace.http?.statusCode !== 304 && (
+                <Field data-test-id="timings" label="Timings">
+                  <a
+                    href="https://github.com/FormidableLabs/envy#web-client-application"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium text-blue-600 dark:text-blue-500 hover:underline"
+                  >
+                    Disabled by CORS policy
+                  </a>
+                </Field>
+              )}
               {trace.http?.timings && (
                 <Field data-test-id="timings" label="Timings">
                   <TimingsDiagram timings={trace.http.timings} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,6 +2438,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@2.8.14":
+  version "2.8.14"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.14.tgz#94eeb1c95eda6a8ab54870a3bf88854512f43a92"
+  integrity sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33":
   version "4.17.36"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
@@ -3805,7 +3812,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cors@^2.8.5:
+cors@2.8.5, cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==


### PR DESCRIPTION
Adds timing data to browser fetch calls via @envyjs/web

Browsers prevent full timing data from being accessed from cross-origin requests unless the server responds with the [Timing-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin) header

Added CORS headers to the Apollo example, so we can see the full dataset. When data is blocked, the UX shows a link to the documentation on how to enable CORS for timing data

With CORS allowed

![image](https://github.com/FormidableLabs/envy/assets/1521394/fbba9c6e-c84b-4693-bf9d-a6041497e931)

Without CORS allowed

![image](https://github.com/FormidableLabs/envy/assets/1521394/41b89db1-43f9-4df5-9a1b-80253c1a7c0e)
