### PR TITLE
Added auto scroll functionality to TraceList

### DIFF
--- a/.changeset/cool-boats-tap.md
+++ b/.changeset/cool-boats-tap.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': minor
+---
+
+Trace list now auto scrolls to bottom when new traces come in. Can be disabled.

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -14,7 +14,7 @@ export default class CollectorClient {
   private _connected: boolean = false;
   private _connecting: boolean = true;
   private _traces: Traces = new Map();
-  private _changeHandler?: () => void;
+  private _changeHandler?: (newTraceId?: string) => void;
 
   constructor({ port, changeHandler }: WebSocketClientOptions) {
     this._port = port ?? DEFAULT_WEB_SOCKET_PORT;
@@ -37,8 +37,8 @@ export default class CollectorClient {
     return this._connecting;
   }
 
-  private _signalChange() {
-    this._changeHandler?.();
+  private _signalChange(newTraceId?: string) {
+    this._changeHandler?.(newTraceId);
   }
 
   private _connect() {
@@ -65,8 +65,10 @@ export default class CollectorClient {
 
   addEvent(event: Event) {
     const trace = { ...event };
+    const isNewTrace = !this._traces.has(trace.id);
+
     this._traces.set(trace.id, trace);
-    this._signalChange();
+    this._signalChange(isNewTrace ? trace.id : undefined);
   }
 
   clearTraces() {

--- a/packages/webui/src/components/ToggleSwitch.test.tsx
+++ b/packages/webui/src/components/ToggleSwitch.test.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ToggleSwitch from './ToggleSwitch';
+
+describe('ToggleSwitch', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render without error', () => {
+    render(<ToggleSwitch />);
+  });
+
+  describe('with label', () => {
+    it('should render label to the left by default', () => {
+      const { getByTestId } = render(<ToggleSwitch label="Foo" />);
+
+      const checkbox = getByTestId('checkbox');
+      const label = getByTestId('label');
+
+      expect(label).toHaveTextContent('Foo');
+      expect(checkbox.previousSibling).toBe(label);
+    });
+
+    it('should render label to the left when specified', () => {
+      const { getByTestId } = render(<ToggleSwitch label="Foo" labelPosition="left" />);
+
+      const checkbox = getByTestId('checkbox');
+      const label = getByTestId('label');
+
+      expect(label).toHaveTextContent('Foo');
+      expect(checkbox.previousSibling).toBe(label);
+    });
+
+    it('should render label to the right when specified', () => {
+      const { getByTestId } = render(<ToggleSwitch label="Foo" labelPosition="right" />);
+
+      const checkbox = getByTestId('checkbox');
+      const label = getByTestId('label');
+
+      expect(label).toHaveTextContent('Foo');
+      expect(checkbox.nextSibling).toBe(label);
+    });
+  });
+
+  describe('initial checked state', () => {
+    it('should not display checkmark by default', () => {
+      const { queryByTestId } = render(<ToggleSwitch />);
+
+      const checkmark = queryByTestId('checkmark');
+      expect(checkmark).not.toBeInTheDocument();
+    });
+
+    it('should not display checkmark when `checked` is false', () => {
+      const { queryByTestId } = render(<ToggleSwitch checked={false} />);
+
+      const checkmark = queryByTestId('checkmark');
+      expect(checkmark).not.toBeInTheDocument();
+    });
+
+    it('should display checkmark when `checked` is true', () => {
+      const { getByTestId } = render(<ToggleSwitch checked={true} />);
+
+      const checkmark = getByTestId('checkmark');
+      expect(checkmark).toBeVisible();
+    });
+  });
+
+  describe('interaction', () => {
+    it('should toggle checkmark on when clicked', async () => {
+      const { container, queryByTestId } = render(<ToggleSwitch />);
+
+      const toggleSwitch = container.firstElementChild!;
+
+      const checkmarkBefore = queryByTestId('checkmark');
+      expect(checkmarkBefore).not.toBeInTheDocument();
+
+      await act(async () => {
+        await userEvent.click(toggleSwitch);
+      });
+
+      const checkmarkAfter = queryByTestId('checkmark');
+      expect(checkmarkAfter).toBeVisible();
+    });
+
+    it('should toggle checkmark off when clicked', async () => {
+      const { container, queryByTestId } = render(<ToggleSwitch checked={true} />);
+
+      const toggleSwitch = container.firstElementChild!;
+
+      const checkmarkBefore = queryByTestId('checkmark');
+      expect(checkmarkBefore).toBeVisible();
+
+      await act(async () => {
+        await userEvent.click(toggleSwitch);
+      });
+
+      const checkmarkAfter = queryByTestId('checkmark');
+      expect(checkmarkAfter).not.toBeInTheDocument();
+    });
+
+    it('should trigger `onChange` handler with `true` when checked', async () => {
+      const onChangeFn = jest.fn();
+
+      const { container } = render(<ToggleSwitch onChange={onChangeFn} />);
+
+      const toggleSwitch = container.firstElementChild!;
+
+      await act(async () => {
+        await userEvent.click(toggleSwitch);
+      });
+
+      expect(onChangeFn).toHaveBeenCalledWith(true);
+    });
+
+    it('should trigger `onChange` handler with `false` when unchecked', async () => {
+      const onChangeFn = jest.fn();
+
+      const { container } = render(<ToggleSwitch onChange={onChangeFn} checked={true} />);
+
+      const toggleSwitch = container.firstElementChild!;
+
+      await act(async () => {
+        await userEvent.click(toggleSwitch);
+      });
+
+      expect(onChangeFn).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/webui/src/components/ToggleSwitch.tsx
+++ b/packages/webui/src/components/ToggleSwitch.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { HiCheck } from 'react-icons/hi';
+
+import { tw } from '@/utils';
+
+type ToggleSwitchProps = Omit<React.HTMLAttributes<HTMLLabelElement>, 'onChange'> & {
+  label?: string;
+  labelPosition?: 'left' | 'right';
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  readOnly?: boolean;
+  disabled?: boolean;
+};
+
+export default function ToggleSwitch({
+  label,
+  labelPosition,
+  checked,
+  onChange,
+  readOnly,
+  disabled,
+  className,
+  ...props
+}: ToggleSwitchProps) {
+  const [isChecked, setIsChecked] = useState(checked ?? false);
+
+  useEffect(() => {
+    setIsChecked(checked ?? false);
+  }, [checked]);
+
+  return (
+    <label
+      className={tw(
+        'flex flex-row items-center bg-slate-100 py-1 px-2 rounded text-black/70',
+        !disabled && !readOnly && 'cursor-pointer hover:bg-white',
+        className,
+      )}
+      {...props}
+    >
+      {label && labelPosition !== 'right' && (
+        <span data-test-id="label" className="mr-2">
+          {label}
+        </span>
+      )}
+      <div
+        data-test-id="checkbox"
+        className={tw('w-6 h-6 rounded', isChecked ? 'bg-green-400' : 'border border-slate-300')}
+      >
+        {isChecked && <HiCheck data-test-id="checkmark" className="w-full h-full text-white" />}
+        <input
+          type="checkbox"
+          className="appearance-none"
+          checked={isChecked}
+          disabled={disabled ?? false}
+          readOnly={readOnly ?? false}
+          onChange={() => {
+            setIsChecked(!isChecked);
+            onChange?.(!isChecked);
+          }}
+        />
+      </div>
+      {label && labelPosition === 'right' && (
+        <span data-test-id="label" className="ml-2">
+          {label}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/webui/src/components/index.ts
+++ b/packages/webui/src/components/index.ts
@@ -15,4 +15,5 @@ export { default as Loading } from './Loading';
 export { default as Menu, MenuItem } from './Menu';
 export { default as SearchInput } from './SearchInput';
 export { default as Section } from './Section';
+export { default as ToggleSwitch } from './ToggleSwitch';
 export { default as XmlDisplay } from './XmlDisplay';

--- a/packages/webui/src/components/ui/TraceList.test.tsx
+++ b/packages/webui/src/components/ui/TraceList.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import mockTraces, { mockTraceCollection } from '@/testing/mockTraces';
@@ -20,9 +20,18 @@ jest.mock('@/components', () => ({
   Loading: function MockLoading() {
     return <>Mock Loading component</>;
   },
+  ToggleSwitch: function MockToggleSwitch({ checked, onChange, ...props }: any) {
+    return (
+      <div {...props} onClick={() => onChange(!checked)}>
+        Mock ToggleSwitch component: {checked ? 'checked' : 'unchecked'}
+      </div>
+    );
+  },
 }));
 
 describe('TraceList', () => {
+  let scrollToFn: jest.Mock;
+
   function setUpTraces(traces: Trace[]) {
     setUseApplicationData({
       traces: traces.reduce((acc, curr) => {
@@ -33,6 +42,9 @@ describe('TraceList', () => {
   }
 
   beforeEach(() => {
+    scrollToFn = jest.fn();
+    Element.prototype.scrollTo = scrollToFn;
+
     setUpTraces(mockTraces);
   });
 
@@ -338,6 +350,44 @@ describe('TraceList', () => {
     });
   });
 
+  describe('footer', () => {
+    beforeEach(() => {
+      setUseApplicationData({
+        traces: mockTraceCollection(),
+      });
+    });
+
+    it('should display number of traces', () => {
+      const { getByTestId } = render(<TraceList />);
+
+      const traceCount = getByTestId('trace-count');
+      expect(traceCount).toBeVisible();
+      expect(traceCount).toHaveTextContent(`Traces: ${mockTraceCollection().size}`);
+    });
+
+    it('should display ToggleSwitch component for auto scroll', () => {
+      const { getByTestId } = render(<TraceList />);
+
+      const autoScroll = getByTestId('auto-scroll');
+      expect(autoScroll).toBeVisible();
+      expect(autoScroll).toHaveTextContent('Mock ToggleSwitch component: checked');
+    });
+
+    it('should toggle auto scroll when the ToggleSwitch component `onChange` handler fires', async () => {
+      const { getByTestId } = render(<TraceList />);
+
+      const autoScrollBefore = getByTestId('auto-scroll');
+      expect(autoScrollBefore).toHaveTextContent('Mock ToggleSwitch component: checked');
+
+      await act(async () => {
+        await userEvent.click(autoScrollBefore);
+      });
+
+      const autoScrollAfter = getByTestId('auto-scroll');
+      expect(autoScrollAfter).toHaveTextContent('Mock ToggleSwitch component: unchecked');
+    });
+  });
+
   describe('missing data', () => {
     it('should render nothing for method and status if `http` property of trace is not defined', () => {
       setUpTraces([
@@ -353,6 +403,88 @@ describe('TraceList', () => {
       const methodData = within(traceRow).getByTestId('column-data-method');
 
       expect(methodData).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('scrolling', () => {
+    it('should scroll to the bottom when a new trace is added', () => {
+      setUseApplicationData({ newestTraceId: '1' });
+
+      // some fake data to validate the set scroll position
+      Object.defineProperties(Element.prototype, {
+        scrollHeight: {
+          value: 400,
+        },
+      });
+
+      render(<TraceList />);
+
+      expect(scrollToFn).toHaveBeenCalledWith({
+        behavior: 'instant',
+        top: 400,
+      });
+    });
+
+    it('should not scroll to the bottom when `autoScroll` is false', () => {
+      setUseApplicationData({ newestTraceId: '1' });
+
+      render(<TraceList autoScroll={false} />);
+
+      expect(scrollToFn).not.toHaveBeenCalled();
+    });
+
+    it('should not scroll to the bottom when `newestTraceId` is undefined', () => {
+      setUseApplicationData({ newestTraceId: undefined });
+
+      render(<TraceList autoScroll={false} />);
+
+      expect(scrollToFn).not.toHaveBeenCalled();
+    });
+
+    it('should set auto scroll to false when scrolling away from the bottom of the container', async () => {
+      // some fake data to validate the set scroll position
+      Object.defineProperties(Element.prototype, {
+        scrollHeight: {
+          value: 400,
+        },
+        clientHeight: {
+          value: 200,
+        },
+        scrollTop: {
+          value: 100, // not at the bottom
+        },
+      });
+
+      const { getByTestId } = render(<TraceList />);
+
+      const scrollContainer = getByTestId('scroll-container');
+      fireEvent.scroll(scrollContainer);
+
+      const autoScroll = getByTestId('auto-scroll');
+      expect(autoScroll).toHaveTextContent('Mock ToggleSwitch component: unchecked');
+    });
+
+    it('should set auto scroll to true when scrolling to the bottom of the container', async () => {
+      // some fake data to validate the set scroll position
+      Object.defineProperties(Element.prototype, {
+        scrollHeight: {
+          value: 400,
+        },
+        clientHeight: {
+          value: 200,
+        },
+        scrollTop: {
+          value: 200, // scroll top 200 means we're at the bottom of the scrollable area
+        },
+      });
+
+      const { getByTestId } = render(<TraceList />);
+
+      const scrollContainer = getByTestId('scroll-container');
+      fireEvent.scroll(scrollContainer);
+
+      const autoScroll = getByTestId('auto-scroll');
+      expect(autoScroll).toHaveTextContent('Mock ToggleSwitch component: checked');
     });
   });
 });

--- a/packages/webui/src/context/ApplicationContext.test.tsx
+++ b/packages/webui/src/context/ApplicationContext.test.tsx
@@ -147,10 +147,22 @@ describe('ApplicationContext', () => {
       });
     });
 
-    it('should expose selecedTraceId as undefined initially', async () => {
+    it('should expose selectedTraceId as undefined initially', async () => {
       function TestComponent() {
         const { selectedTraceId } = useContext(ApplicationContext);
         return <div data-test-id="value">{selectedTraceId ?? 'undefined'}</div>;
+      }
+
+      const { getByTestId } = renderComponentInProvider(<TestComponent />);
+      const value = getByTestId('value');
+
+      expect(value).toHaveTextContent('undefined');
+    });
+
+    it('should expose newestTraceId as undefined initially', async () => {
+      function TestComponent() {
+        const { newestTraceId } = useContext(ApplicationContext);
+        return <div data-test-id="value">{newestTraceId ?? 'undefined'}</div>;
       }
 
       const { getByTestId } = renderComponentInProvider(<TestComponent />);
@@ -701,6 +713,28 @@ describe('ApplicationContext', () => {
 
       const valueAfter = getByTestId('value');
       expect(valueAfter).toHaveTextContent('undefined');
+    });
+  });
+
+  describe('broadcasting updates', () => {
+    it('should update `newestTraceId` when the client collector triggers its change handler with a `newTraceId`', () => {
+      mockCollector.mockImplementation(({ changeHandler }) => {
+        return {
+          start() {
+            changeHandler('1');
+          },
+        } as unknown as CollectorClient;
+      });
+
+      function TestComponent() {
+        const { newestTraceId } = useContext(ApplicationContext);
+        return <div data-test-id="value">{newestTraceId ?? 'undefined'}</div>;
+      }
+
+      const { getByTestId } = renderComponentInProvider(<TestComponent />);
+      const value = getByTestId('value');
+
+      expect(value).toHaveTextContent('1');
     });
   });
 });

--- a/packages/webui/src/context/ApplicationContext.tsx
+++ b/packages/webui/src/context/ApplicationContext.tsx
@@ -19,9 +19,11 @@ export default function ApplicationContextProvider({ children }: React.HTMLAttri
   // TODO: find a better way to force a redraw
   const [, forceUpdate] = useState<boolean>(false);
   const [selectedTraceId, setSelectedTraceId] = useState<string | undefined>();
+  const [newestTraceId, setNewestTraceId] = useState<string | undefined>();
   const [filter, setFilter] = useState<TraceFilter | undefined>();
 
-  const changeHandler = () => {
+  const changeHandler = (newTraceId?: string) => {
+    if (newTraceId) setNewestTraceId(newTraceId);
     forceUpdate(curr => !curr);
   };
 
@@ -99,7 +101,8 @@ export default function ApplicationContextProvider({ children }: React.HTMLAttri
         return filteredTraces;
       }
     },
-    selectedTraceId: selectedTraceId,
+    selectedTraceId,
+    newestTraceId,
     setSelectedTrace(id: string) {
       setSelectedTraceId(() => id);
     },

--- a/packages/webui/src/hooks/useApplication.ts
+++ b/packages/webui/src/hooks/useApplication.ts
@@ -10,6 +10,7 @@ export type ApplicationContextData = {
   connected: boolean;
   traces: Traces;
   selectedTraceId?: string;
+  newestTraceId?: string;
   getSelectedTrace: () => Trace | undefined;
   setSelectedTrace: (id: string) => void;
   clearSelectedTrace: () => void;

--- a/packages/webui/src/testing/setupJest.ts
+++ b/packages/webui/src/testing/setupJest.ts
@@ -1,3 +1,6 @@
 import { configure } from '@testing-library/react';
 
 configure({ testIdAttribute: 'data-test-id' });
+
+// JSDom does not implement scrollTo, so we just need to mock it here
+Element.prototype.scrollTo = () => void 0;


### PR DESCRIPTION
## What does this PR do?

- Adds auto-scroll functionality to the trace list, so that new traces force the list to scroll to the bottom
- Adds an auto-scroll indicator and toggle in a new "footer" in the trace list (which also lists number of traces)

Auto scroll will be enabled when:
- Envy first loads
- The user checks the "auto scroll" checkbox in the footer
- The user scrolls to the bottom of the trace list

Auto scroll will be disabled when:
- The user unchecks the "auto scroll" checkbox in the footer
- The user scrolls away from the bottom of the trace list

Closes #73 

## Demo

![EnvyAutoScroll](https://github.com/FormidableLabs/envy/assets/17857833/7af300ef-9371-48ab-9926-fa53e0e2a600)