### PR TITLE
Updated KeyValuList component column sizing

### DIFF
--- a/.changeset/khaki-cameras-juggle.md
+++ b/.changeset/khaki-cameras-juggle.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Updated column widths in KeyValueList component

--- a/packages/webui/src/components/KeyValueList.tsx
+++ b/packages/webui/src/components/KeyValueList.tsx
@@ -12,27 +12,29 @@ export default function KeyValueList({ label, keyValuePairs }: KeyValueListProps
 
   return (
     <Field label={label}>
-      {keyValuePairs.map(([k, v]) => {
-        let value: React.ReactNode = v;
-        switch (typeof v) {
-          case 'string': {
-            value = decodeURIComponent(v);
-            break;
+      <div className="table w-full">
+        {keyValuePairs.map(([k, v]) => {
+          let value: React.ReactNode = v;
+          switch (typeof v) {
+            case 'string': {
+              value = decodeURIComponent(v);
+              break;
+            }
+            case 'number':
+            case 'boolean': {
+              value = v.toString();
+              break;
+            }
           }
-          case 'number':
-          case 'boolean': {
-            value = v.toString();
-            break;
-          }
-        }
 
-        return (
-          <span data-test-id="key-value-item" key={k} className="w-full flex flex-row pt-2 first:pt-0">
-            <span className="flex-[1] font-semibold">{k}: </span>
-            <span className="group flex-[3] break-all overflow-x-visible">{value}</span>
-          </span>
-        );
-      })}
+          return (
+            <span data-test-id="key-value-item" key={k} className="w-full table-row pt-2 first:pt-0">
+              <span className="table-cell whitespace-nowrap font-semibold py-1 pr-4 min-w-[12rem]">{k}: </span>
+              <span className="group table-cell w-full break-all overflow-x-visible py-1">{value}</span>
+            </span>
+          );
+        })}
+      </div>
     </Field>
   );
 }


### PR DESCRIPTION
## What does this PR do?

- Change the column sizing in the `KeyValuePair` component to be more dynamic based on the header names, rather than a fixed `flex: 1 / flex: 3` split.

Fixes #95 

## Screenshots

### Before :-1:
![image](https://github.com/FormidableLabs/envy/assets/17857833/dd1ec482-6bde-4f56-8b04-fbb6eed85de3)

### After :+1:
![image](https://github.com/FormidableLabs/envy/assets/17857833/79f4d615-7ba9-4549-acf9-148de761de79)

### With long header names
![image](https://github.com/FormidableLabs/envy/assets/17857833/778d2b2b-e3bf-4bdc-bcb4-c09b35a298ca)
