### PR TITLE
Fixed automatic auto-scroll bug

### DIFF
--- a/.changeset/slimy-coins-learn.md
+++ b/.changeset/slimy-coins-learn.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Fix bug where auto-scroll would sometime not be enabled when scrolling to the bottom whilst zoomed in

--- a/packages/webui/src/components/ui/TraceList.tsx
+++ b/packages/webui/src/components/ui/TraceList.tsx
@@ -104,7 +104,7 @@ export default function TraceList({ autoScroll: initialAutoScroll = true, classN
   ];
 
   const [Icon, message] = connected
-    ? [HiStatusOnline, `Listening for traces...`]
+    ? [HiStatusOnline, `Connected to ws://127.0.0.1:${port}/ ...`]
     : connecting
     ? [HiOutlineLightningBolt, 'Connecting...']
     : [HiOutlineEmojiSad, 'Unable to connect'];

--- a/packages/webui/src/components/ui/TraceList.tsx
+++ b/packages/webui/src/components/ui/TraceList.tsx
@@ -55,7 +55,7 @@ export default function TraceList({ autoScroll: initialAutoScroll = true, classN
     const totalHeight = target.scrollHeight;
     const viewportHeight = target.clientHeight;
     const maxScrollTop = totalHeight - viewportHeight;
-    const scrollTop = Math.round(target.scrollTop);
+    const scrollTop = Math.ceil(target.scrollTop);
 
     setAutoScroll(scrollTop >= maxScrollTop);
   }
@@ -104,7 +104,7 @@ export default function TraceList({ autoScroll: initialAutoScroll = true, classN
   ];
 
   const [Icon, message] = connected
-    ? [HiStatusOnline, `Connected to ws://127.0.0.1:${port}/ ...`]
+    ? [HiStatusOnline, `Listening for traces...`]
     : connecting
     ? [HiOutlineLightningBolt, 'Connecting...']
     : [HiOutlineEmojiSad, 'Unable to connect'];


### PR DESCRIPTION
## What does this PR do

- Tweak how we calculate when you've scrolled to the bottom of the trace list (in order to enable auto-scroll)
- **When zoomed in using the browser zoom features**, scroll position was a floating point number which would sometimes round down and therefore not correctly track as being at the bottom of the scroll container.
- Changing to always round up ensures that the automatic setting of auto-scroll when scrolling to the bottom of the trace list works at all zoom levels