### PR TITLE
Added scoping to web socket message payloads

### DIFF
--- a/.changeset/empty-poems-wonder.md
+++ b/.changeset/empty-poems-wonder.md
@@ -1,0 +1,8 @@
+---
+'@envyjs/webui': minor
+'@envyjs/core': minor
+'@envyjs/node': minor
+'@envyjs/web': minor
+---
+
+Updated web socket message payloads to scope by type

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,5 +7,6 @@ export * from './json';
 export * from './middleware';
 export * from './nanoid';
 export * from './options';
+export * from './payload';
 export * from './plugin';
 export * from './sanity';

--- a/packages/core/src/payload.ts
+++ b/packages/core/src/payload.ts
@@ -1,0 +1,19 @@
+import { Event } from './event';
+
+// TODO: add more payload types, such as connection status
+// e.g.,
+// export type ConnectionStatusPayload = {
+//   type: 'connections',
+//   data: [string, boolean][]
+// }
+
+export type TracePayload = {
+  type: 'trace';
+  data: Event;
+};
+
+// TODO: WebSocketPayload can represent the various payload types
+// e.g.,
+// export type WebSocketPayload = ConnectionStatusPayload | TracePayload | etc...
+
+export type WebSocketPayload = TracePayload;

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -67,17 +67,23 @@ export function WebSocketClient(options: WebSocketClientOptions) {
       }
 
       try {
-        ws.send(JSON.stringify(data), error => {
-          if (options.debug) {
-            if (ws.readyState === ws.CLOSED || ws.readyState === ws.CLOSING) {
-              log.debug('event not sent, websocket closed');
-            } else if (ws.readyState === ws.CONNECTING) {
-              log.debug('event not sent, websocket still connecting');
-            } else {
-              if (error) log.debug('websocket send', { error });
+        ws.send(
+          JSON.stringify({
+            type: 'trace',
+            data,
+          }),
+          error => {
+            if (options.debug) {
+              if (ws.readyState === ws.CLOSED || ws.readyState === ws.CLOSING) {
+                log.debug('event not sent, websocket closed');
+              } else if (ws.readyState === ws.CONNECTING) {
+                log.debug('event not sent, websocket still connecting');
+              } else {
+                if (error) log.debug('websocket send', { error });
+              }
             }
-          }
-        });
+          },
+        );
       } catch (error) {
         if (options.debug) {
           log.debug('websocket error');

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -24,8 +24,13 @@ export function WebSocketClient(options: WebSocketClientOptions) {
       log.info('client connected');
       retryDelay = DEFAULT_RETRY_DELAY;
 
-      for (const trace of Object.values(initialTraces)) {
-        ws.send(JSON.stringify(trace));
+      for (const data of Object.values(initialTraces)) {
+        ws.send(
+          JSON.stringify({
+            type: 'trace',
+            data,
+          }),
+        );
       }
     };
 
@@ -66,7 +71,12 @@ export function WebSocketClient(options: WebSocketClientOptions) {
 
       try {
         if (ws.readyState === ws.OPEN) {
-          ws.send(JSON.stringify(data));
+          ws.send(
+            JSON.stringify({
+              type: 'trace',
+              data,
+            }),
+          );
         } else {
           initialTraces[data.id] = data;
         }

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WEB_SOCKET_PORT, Event, safeParseJson } from '@envyjs/core';
+import { DEFAULT_WEB_SOCKET_PORT, Event, WebSocketPayload, safeParseJson } from '@envyjs/core';
 
 import { Traces } from '@/types';
 
@@ -51,9 +51,14 @@ export default class CollectorClient {
     });
 
     socket.addEventListener('message', ({ data }) => {
-      const payload = safeParseJson<Event>(data.toString());
-      if (payload.value) {
-        this.addEvent(payload.value);
+      const payload = safeParseJson<WebSocketPayload>(data.toString());
+      if (!payload.value) return;
+
+      switch (payload.value.type) {
+        case 'trace': {
+          this.addEvent(payload.value.data);
+          break;
+        }
       }
     });
   }

--- a/packages/webui/src/scripts/startCollector.cjs
+++ b/packages/webui/src/scripts/startCollector.cjs
@@ -42,6 +42,7 @@ wss.on('connection', (ws, request) => {
     }
 
     try {
+      // the collector just relays incoming messages to the viewer; if one is available
       viewer.send(data.toString());
     } catch (e) {
       handleError(`Unable to parse message: ${e}`);


### PR DESCRIPTION
## What does this PR do?

- Updates the WS messages sent from `@envyjs/web` and `@envyjs/node` to be scoped as `type: 'trace'`
- Updates `@envyjs/webui` to handle WS messages based on the `type` in the payload

I.e.,
```diff
- ws.send(JSON.stringify(trace));
+ ws.send(JSON.stringify({ type: 'trace', data: trace });
```

- This gives us the capability in future to support different types of WS message payloads without having backwards compatibility issues with exceptions of payload content.

Fixes: #106 