### PR TITLE
Display connected senders (sources)

### DIFF
--- a/.changeset/brave-points-admire.md
+++ b/.changeset/brave-points-admire.md
@@ -1,0 +1,8 @@
+---
+'@envyjs/webui': minor
+'@envyjs/core': minor
+'@envyjs/node': minor
+'@envyjs/web': minor
+---
+
+Connection status of senders (sources) exposed in @envyjs/webui viewer

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "example:apollo": "concurrently \"cd examples/apollo && yarn start\" \"cd examples/apollo-client && yarn start:custom-viewer\"",
+    "example:apollo": "concurrently \"cd examples/apollo && yarn start\" \"cd examples/apollo-client && yarn start\"",
+    "example:apollo:custom-viewer": "concurrently \"cd examples/apollo && yarn start\" \"cd examples/apollo-client && yarn start\"",
     "example:express": "concurrently \"cd examples/express && yarn start\" \"cd examples/express-client && yarn dev\"",
     "example:next": "cd examples/next && yarn && yarn dev",
     "changeset": "changeset"

--- a/packages/core/src/payload.ts
+++ b/packages/core/src/payload.ts
@@ -1,19 +1,17 @@
 import { Event } from './event';
 
-// TODO: add more payload types, such as connection status
-// e.g.,
-// export type ConnectionStatusPayload = {
-//   type: 'connections',
-//   data: [string, boolean][]
-// }
+// how the 'connections' data will arrive from the collector
+// [serviceName: string, isActive: boolean][]
+export type ConnectionStatusData = [string, boolean][];
+
+export type ConnectionStatusPayload = {
+  type: 'connections';
+  data: ConnectionStatusData;
+};
 
 export type TracePayload = {
   type: 'trace';
   data: Event;
 };
 
-// TODO: WebSocketPayload can represent the various payload types
-// e.g.,
-// export type WebSocketPayload = ConnectionStatusPayload | TracePayload | etc...
-
-export type WebSocketPayload = TracePayload;
+export type WebSocketPayload = ConnectionStatusPayload | TracePayload;

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -14,19 +14,9 @@ export function WebSocketClient(options: WebSocketClientOptions) {
   let ws: WebSocket;
   let retryDelay = DEFAULT_RETRY_DELAY;
   let retryAttempts = 0;
-  let pinger: NodeJS.Timeout | undefined = undefined;
 
   const identifier = `node/${options.serviceName}`;
   const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/${identifier}`;
-
-  function ping(ws: WebSocket) {
-    ws.send(
-      JSON.stringify({
-        type: 'ping',
-        data: identifier,
-      }),
-    );
-  }
 
   function connect() {
     ws = new WebSocket(socket);
@@ -34,19 +24,10 @@ export function WebSocketClient(options: WebSocketClientOptions) {
     ws.on('open', () => {
       log.info('client connected');
       retryDelay = DEFAULT_RETRY_DELAY;
-
-      // ping immediately and every 5 seconds to assert connection
-      ping(ws);
-      pinger = setInterval(() => ping(ws), 5_000);
     });
 
     ws.on('close', () => {
       log.error('client disconnected');
-
-      // stop pinging; allow connection to expire
-      if (pinger) {
-        clearInterval(pinger);
-      }
 
       reconnect();
     });

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -14,8 +14,19 @@ export function WebSocketClient(options: WebSocketClientOptions) {
   let ws: WebSocket;
   let retryDelay = DEFAULT_RETRY_DELAY;
   let retryAttempts = 0;
+  let pinger: NodeJS.Timeout | undefined = undefined;
 
-  const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/node/${options.serviceName}`;
+  const identifier = `node/${options.serviceName}`;
+  const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/${identifier}`;
+
+  function ping(ws: WebSocket) {
+    ws.send(
+      JSON.stringify({
+        type: 'ping',
+        data: identifier,
+      }),
+    );
+  }
 
   function connect() {
     ws = new WebSocket(socket);
@@ -23,10 +34,20 @@ export function WebSocketClient(options: WebSocketClientOptions) {
     ws.on('open', () => {
       log.info('client connected');
       retryDelay = DEFAULT_RETRY_DELAY;
+
+      // ping immediately and every 5 seconds to assert connection
+      ping(ws);
+      pinger = setInterval(() => ping(ws), 5_000);
     });
 
     ws.on('close', () => {
       log.error('client disconnected');
+
+      // stop pinging; allow connection to expire
+      if (pinger) {
+        clearInterval(pinger);
+      }
+
       reconnect();
     });
 

--- a/packages/web/src/client.ts
+++ b/packages/web/src/client.ts
@@ -14,8 +14,19 @@ export function WebSocketClient(options: WebSocketClientOptions) {
   let ws: WebSocket;
   let retryDelay = DEFAULT_RETRY_DELAY;
   let retryAttempts = 0;
+  let pinger: NodeJS.Timeout | undefined = undefined;
 
-  const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/web/${options.serviceName}`;
+  const identifier = `web/${options.serviceName}`;
+  const socket = `ws://127.0.0.1:${options.port ?? DEFAULT_WEB_SOCKET_PORT}/${identifier}`;
+
+  function ping(ws: WebSocket) {
+    ws.send(
+      JSON.stringify({
+        type: 'ping',
+        data: identifier,
+      }),
+    );
+  }
 
   function connect() {
     ws = new WebSocket(socket);
@@ -23,6 +34,10 @@ export function WebSocketClient(options: WebSocketClientOptions) {
     ws.onopen = () => {
       log.info('client connected');
       retryDelay = DEFAULT_RETRY_DELAY;
+
+      // ping immediately and every 5 seconds to assert connection
+      ping(ws);
+      pinger = setInterval(() => ping(ws), 5_000);
 
       for (const data of Object.values(initialTraces)) {
         ws.send(
@@ -36,6 +51,12 @@ export function WebSocketClient(options: WebSocketClientOptions) {
 
     ws.onclose = () => {
       log.error('client disconnected');
+
+      // stop pinging; allow connection to expire
+      if (pinger) {
+        clearInterval(pinger);
+      }
+
       reconnect();
     };
 

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -7,11 +7,17 @@ type WebSocketClientOptions = {
   changeHandler?: () => void;
 };
 
+type ConnectionStatus = {
+  lastPing: number;
+  timeout: NodeJS.Timeout;
+};
+
 export default class CollectorClient {
   private readonly _port: number;
 
   private _connected: boolean = false;
   private _connecting: boolean = true;
+  private _connections: Map<string, ConnectionStatus> = new Map();
   private _traces: Traces = new Map();
   private _changeHandler?: (newTraceId?: string) => void;
 
@@ -34,6 +40,10 @@ export default class CollectorClient {
 
   get connecting() {
     return this._connecting;
+  }
+
+  get connections() {
+    return [...this._connections.keys()];
   }
 
   private _signalChange(newTraceId?: string) {
@@ -59,8 +69,38 @@ export default class CollectorClient {
           this.addEvent(payload.value.data);
           break;
         }
+        case 'ping' as any:
+          this._registerConnection(payload.value.data as any);
+          break;
       }
     });
+  }
+
+  private _registerConnection(identifier: string) {
+    const thisPing = Date.now();
+
+    // if we already have a timeout for this connection, clear it
+    const status = this._connections.get(identifier);
+    if (status?.timeout) {
+      clearTimeout(status.timeout);
+    }
+
+    // set timer to assume this connection is closed after 6s if the most recent ping hasn't updated
+    const timeout = setTimeout(() => {
+      const status = this._connections.get(identifier);
+      if (status?.lastPing === thisPing) {
+        this._connections.delete(identifier);
+        this._signalChange();
+      }
+    }, 6_000);
+
+    // set time of most recent ping
+    this._connections.set(identifier, {
+      lastPing: thisPing,
+      timeout,
+    });
+
+    this._signalChange();
   }
 
   start() {

--- a/packages/webui/src/components/DropDown.tsx
+++ b/packages/webui/src/components/DropDown.tsx
@@ -79,11 +79,11 @@ function DropDown(
 
   return (
     <div ref={finalRef} className={tw('flex input-container self-stretch', className)} {...props}>
-      <span className="group absolute top-0 left-0 cursor-pointer w-full z-50">
+      <span className="group absolute top-0 left-0 w-full z-50">
         <span
           role="listbox"
           data-test-item="list-selection"
-          className={tw('relative flex input', isOpen && 'bg-white rounded-b-none hover:shadow-none')}
+          className={tw('relative flex input cursor-pointer', isOpen && 'bg-white rounded-b-none hover:shadow-none')}
           onClick={() => setIsOpen(curr => !curr)}
         >
           {selection.length === 0 ? (
@@ -117,7 +117,12 @@ function DropDown(
               {items.map(x => {
                 const isSelected = selection.some(y => y.value === x.value);
                 return (
-                  <li data-test-id="list-items-item" key={x.value} onClick={() => handleSelection(x)}>
+                  <li
+                    key={x.value}
+                    data-test-id="list-items-item"
+                    className="cursor-pointer"
+                    onClick={() => handleSelection(x)}
+                  >
                     <span
                       className={tw(
                         'transition-all p-2 flex flex-row items-center rounded bg-white border border-transparent hover:bg-slate-100',

--- a/packages/webui/src/components/Menu.tsx
+++ b/packages/webui/src/components/Menu.tsx
@@ -18,10 +18,14 @@ type MenuProps = React.HTMLAttributes<HTMLDivElement> & {
   Icon?: IconType;
   label: string;
   items: MenuItem[];
+  menuClassName?: string;
   focusKey?: string;
 };
 
-function Menu({ Icon, label, items, className, focusKey, ...props }: MenuProps, ref: Ref<HTMLDivElement>) {
+function Menu(
+  { Icon, label, items, className, menuClassName, focusKey, ...props }: MenuProps,
+  ref: Ref<HTMLDivElement>,
+) {
   const { isMac, specialKey } = usePlatform();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -53,22 +57,33 @@ function Menu({ Icon, label, items, className, focusKey, ...props }: MenuProps, 
 
   return (
     <div ref={finalRef} className={tw('flex input-container', className)} {...props}>
-      <span className="w-full relative group cursor-pointer z-50">
+      <span className="w-full relative group z-50">
         <IconButton
           role="menu"
           type="ghost"
-          className={tw('w-full h-10 relative flex', isOpen && 'bg-white rounded-b-none hover:shadow-none')}
+          className={tw(
+            'w-full h-10 relative flex cursor-pointer',
+            isOpen && 'bg-white rounded-b-none hover:shadow-none hover:bg-white',
+          )}
           Icon={Icon}
           onClick={() => setIsOpen(curr => !curr)}
         >
           {label}
         </IconButton>
         {isOpen && (
-          <span data-test-id="menu-items" className="input w-full absolute top-full left-0 bg-white rounded-t-none">
+          <span
+            data-test-id="menu-items"
+            className={tw('input w-full absolute top-full left-0 bg-white rounded-t-none', menuClassName)}
+          >
             <ul className="flex flex-col gap-1">
               {items.map((x: MenuItem) => {
                 return (
-                  <li data-test-id="menu-items-item" key={x.label} onClick={() => handleSelection(x)}>
+                  <li
+                    key={x.label}
+                    data-test-id="menu-items-item"
+                    className="cursor-pointer"
+                    onClick={() => handleSelection(x)}
+                  >
                     <span className="transition-all p-2 flex flex-row items-center rounded bg-white border border-transparent hover:bg-slate-100">
                       <span className="flex-1">
                         <span data-test-id="label" className="block">

--- a/packages/webui/src/components/ui/ConnectionStatus.tsx
+++ b/packages/webui/src/components/ui/ConnectionStatus.tsx
@@ -7,7 +7,7 @@ export default function ConnectionStatus() {
   const { connecting, connected } = useApplication();
 
   return (
-    <>
+    <div className="w-6 h-6">
       {connecting ? (
         <Loading size={4} />
       ) : connected ? (
@@ -15,6 +15,6 @@ export default function ConnectionStatus() {
       ) : (
         <HiStatusOffline className="w-full h-full text-red-600" />
       )}
-    </>
+    </div>
   );
 }

--- a/packages/webui/src/components/ui/DebugToolbar.test.tsx
+++ b/packages/webui/src/components/ui/DebugToolbar.test.tsx
@@ -7,7 +7,7 @@ import { setUseApplicationData } from '@/testing/mockUseApplication';
 import DebugToolbar from './DebugToolbar';
 
 jest.mock('@/components', () => ({
-  Menu: function ({ label, items, ...props }: any) {
+  Menu: function ({ label, items, menuClassName, Icon, ...props }: any) {
     return (
       <div {...props}>
         <div>{label}</div>

--- a/packages/webui/src/components/ui/DebugToolbar.tsx
+++ b/packages/webui/src/components/ui/DebugToolbar.tsx
@@ -1,3 +1,5 @@
+import { HiOutlinePuzzle } from 'react-icons/hi';
+
 import { Menu, MenuItem } from '@/components';
 import useApplication from '@/hooks/useApplication';
 import mockData from '@/testing/mockTraces';
@@ -25,5 +27,13 @@ export default function DebugToolbar() {
     },
   ];
 
-  return <Menu data-test-id="debug-menu" className="w-52" label="Debug menu" items={debugOptions} />;
+  return (
+    <Menu
+      data-test-id="debug-menu"
+      menuClassName="w-52"
+      label="Debug menu"
+      Icon={HiOutlinePuzzle}
+      items={debugOptions}
+    />
+  );
 }

--- a/packages/webui/src/components/ui/FiltersAndActions.tsx
+++ b/packages/webui/src/components/ui/FiltersAndActions.tsx
@@ -1,53 +1,29 @@
-import { useEffect, useState } from 'react';
 import { HiTrash } from 'react-icons/hi';
 
-import { DropDown, IconButton, SearchInput } from '@/components';
+import { IconButton, SearchInput } from '@/components';
 import useApplication from '@/hooks/useApplication';
-import { getDefaultSystem, getRegisteredSystems } from '@/systems/registration';
+
+import SourceAndSystemFilter from './SourceAndSystemFilter';
 
 export default function FiltersAndActions() {
-  const { filterTraces, clearTraces } = useApplication();
-  const [selectedSystems, setSelectedSystems] = useState<string[]>([]);
-  const [filter, setFilter] = useState<string>('');
-
-  useEffect(() => {
-    filterTraces(selectedSystems, filter);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSystems, filter]);
-
-  const defaultSystem = getDefaultSystem();
-  const systems = getRegisteredSystems();
+  const { setFilters, clearTraces } = useApplication();
 
   function clearData() {
     clearTraces();
   }
 
-  function handleSystemsChange(value: string[]) {
-    setSelectedSystems(value);
-  }
-
-  function handleFilterChange(value: string) {
-    setFilter(value);
+  function handleSearchTermChange(value: string) {
+    setFilters(curr => ({
+      ...curr,
+      searchTerm: value,
+    }));
   }
 
   return (
     <span className="flex flex-row items-center gap-2">
-      {systems.length > 0 && (
-        <DropDown
-          className="w-60"
-          focusKey="S"
-          placeholder="Systems..."
-          label="Systems:"
-          multiSelect
-          items={systems.map(x => ({
-            icon: x.getIconUri?.() ?? defaultSystem.getIconUri(),
-            value: x.name,
-          }))}
-          onChange={handleSystemsChange}
-        />
-      )}
+      <SourceAndSystemFilter data-test-id="sources-and-systems" className="w-96" />
 
-      <SearchInput className="w-96" focusKey="K" placeholder="Filter..." onChange={handleFilterChange} />
+      <SearchInput className="w-72" focusKey="K" placeholder="Search term..." onChange={handleSearchTermChange} />
 
       <IconButton Icon={HiTrash} type="ghost" onClick={clearData}>
         Clear

--- a/packages/webui/src/components/ui/Header.tsx
+++ b/packages/webui/src/components/ui/Header.tsx
@@ -1,3 +1,4 @@
+import useApplication from '@/hooks/useApplication';
 import { tw } from '@/utils';
 
 import ConnectionStatus from './ConnectionStatus';
@@ -5,7 +6,9 @@ import DebugToolbar from './DebugToolbar';
 import FiltersAndActions from './FiltersAndActions';
 
 export default function Header({ className, children, ...props }: React.HTMLAttributes<HTMLElement>) {
+  const { connections } = useApplication();
   const isDebugMode = process.env.NODE_ENV === 'development';
+  const connectionTypeLabel = connections.length === 1 ? 'source' : 'sources';
 
   return (
     <header
@@ -19,10 +22,15 @@ export default function Header({ className, children, ...props }: React.HTMLAttr
     >
       <span className="flex-0 mr-2">
         <span className="flex items-center py-2">
-          <span className="flex items-center justify-center mr-2 w-6 h-6">
+          <span className="mr-2">
             <ConnectionStatus />
           </span>
-          <h1 className="font-extrabold text-xl uppercase mr-2 select-none ">Envy</h1>
+          <h1 className="font-extrabold text-xl uppercase mr-4 select-none">Envy</h1>
+          <div className="flex flex-row text-slate-400 text-sm font-bold">
+            <div title={connections.length > 0 ? connections.join(', ') : undefined}>
+              {connections.length} {connectionTypeLabel} connected
+            </div>
+          </div>
         </span>
       </span>
       <span className="flex-0 flex items-center ml-auto gap-2">

--- a/packages/webui/src/components/ui/Header.tsx
+++ b/packages/webui/src/components/ui/Header.tsx
@@ -1,4 +1,3 @@
-import useApplication from '@/hooks/useApplication';
 import { tw } from '@/utils';
 
 import ConnectionStatus from './ConnectionStatus';
@@ -6,10 +5,7 @@ import DebugToolbar from './DebugToolbar';
 import FiltersAndActions from './FiltersAndActions';
 
 export default function Header({ className, children, ...props }: React.HTMLAttributes<HTMLElement>) {
-  const { activeConnections } = useApplication();
-
   const isDebugMode = process.env.NODE_ENV === 'development';
-  const connectionTypeLabel = activeConnections.length === 1 ? 'source' : 'sources';
 
   return (
     <header
@@ -27,11 +23,6 @@ export default function Header({ className, children, ...props }: React.HTMLAttr
             <ConnectionStatus />
           </span>
           <h1 className="font-extrabold text-xl uppercase mr-4 select-none">Envy</h1>
-          <div className="flex flex-row text-slate-400 text-sm font-bold">
-            <div title={activeConnections.map(([serviceName]) => serviceName).join(', ')}>
-              {activeConnections.length} {connectionTypeLabel} connected
-            </div>
-          </div>
         </span>
       </span>
       <span className="flex-0 flex items-center ml-auto gap-2">

--- a/packages/webui/src/components/ui/Header.tsx
+++ b/packages/webui/src/components/ui/Header.tsx
@@ -6,9 +6,10 @@ import DebugToolbar from './DebugToolbar';
 import FiltersAndActions from './FiltersAndActions';
 
 export default function Header({ className, children, ...props }: React.HTMLAttributes<HTMLElement>) {
-  const { connections } = useApplication();
+  const { activeConnections } = useApplication();
+
   const isDebugMode = process.env.NODE_ENV === 'development';
-  const connectionTypeLabel = connections.length === 1 ? 'source' : 'sources';
+  const connectionTypeLabel = activeConnections.length === 1 ? 'source' : 'sources';
 
   return (
     <header
@@ -27,8 +28,8 @@ export default function Header({ className, children, ...props }: React.HTMLAttr
           </span>
           <h1 className="font-extrabold text-xl uppercase mr-4 select-none">Envy</h1>
           <div className="flex flex-row text-slate-400 text-sm font-bold">
-            <div title={connections.length > 0 ? connections.join(', ') : undefined}>
-              {connections.length} {connectionTypeLabel} connected
+            <div title={activeConnections.map(([serviceName]) => serviceName).join(', ')}>
+              {activeConnections.length} {connectionTypeLabel} connected
             </div>
           </div>
         </span>

--- a/packages/webui/src/components/ui/SourceAndSystemFilter.test.tsx
+++ b/packages/webui/src/components/ui/SourceAndSystemFilter.test.tsx
@@ -1,0 +1,650 @@
+import { act, cleanup, render, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ApplicationContextData, Filters } from '@/hooks/useApplication';
+import { mockSystems, setupMockSystems } from '@/testing/mockSystems';
+import { setUseApplicationData as callSetUseApplicationData } from '@/testing/mockUseApplication';
+
+import SourceAndSystemFilter from './SourceAndSystemFilter';
+
+jest.mock('react-icons/hi', () => ({
+  HiOutlineFilter: function MockHiOutlineFilter() {
+    return <>Mock HiOutlineFilter component</>;
+  },
+  HiX: function MockHiX() {
+    return <>Mock HiX component</>;
+  },
+  HiCheck: function MockHiCheck() {
+    return <>Mock HiCheck component</>;
+  },
+}));
+
+describe('SourceAndSystemFilter', () => {
+  let setFiltersFn: jest.Mock;
+
+  function setUseApplicationData(data: Partial<ApplicationContextData> = {}) {
+    setFiltersFn = jest.fn();
+
+    callSetUseApplicationData({
+      connections: [
+        ['source1', true],
+        ['source2', true],
+        ['source3', false],
+      ],
+      filters: {
+        sources: [],
+        systems: [],
+        searchTerm: '',
+      },
+      setFilters: setFiltersFn,
+      ...data,
+    });
+  }
+
+  async function openDropDown() {
+    const renderResult = render(<SourceAndSystemFilter />);
+
+    await act(async () => {
+      const component = renderResult.getByRole('listbox');
+      await userEvent.click(component);
+    });
+
+    return renderResult;
+  }
+
+  function assertSetFilterUpdate(currentFilters: Filters, expectedValue: Filters) {
+    const updateFn = setFiltersFn.mock.lastCall?.[0];
+    const updateFnResult = updateFn(currentFilters);
+
+    expect(updateFnResult).toEqual(expectedValue);
+  }
+
+  beforeEach(() => {
+    setUseApplicationData();
+    setupMockSystems();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render without error', () => {
+    render(<SourceAndSystemFilter />);
+  });
+
+  it('should render a component with the role "listbox"', () => {
+    const { getByRole } = render(<SourceAndSystemFilter />);
+
+    const component = getByRole('listbox');
+    expect(component).toBeVisible();
+  });
+
+  describe('placeholder', () => {
+    it('should display expected placeholder in the listbox when there are no registered systems', () => {
+      // mock that there are no registered systems
+      setupMockSystems([]);
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('Sources...');
+    });
+
+    it('should display expected placeholder in the listbox when there is one or more registered systems', () => {
+      setupMockSystems(mockSystems);
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('Sources and systems...');
+    });
+  });
+
+  describe('selection summary', () => {
+    it('should display expected selection summary when one source is selected', () => {
+      const filters: Filters = {
+        sources: ['source1'],
+        systems: [],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('1 source');
+    });
+
+    it('should display expected selection summary when two sources are selected', () => {
+      const filters: Filters = {
+        sources: ['source1', 'source2'],
+        systems: [],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('2 sources');
+    });
+
+    it('should display expected selection summary when one system is selected', () => {
+      const filters: Filters = {
+        sources: [],
+        systems: [mockSystems[0].name],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('1 system');
+    });
+
+    it('should display expected selection summary when two systems are selected', () => {
+      const filters: Filters = {
+        sources: [],
+        systems: [mockSystems[0].name, mockSystems[1].name],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('2 systems');
+    });
+
+    it('should display expected selection summary when a combination of sources and systems are selected', () => {
+      const filters: Filters = {
+        sources: ['source1'],
+        systems: [mockSystems[0].name, mockSystems[1].name],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('1 source, 2 systems');
+    });
+
+    it('should display the placeholder when no sources or systems are selected', () => {
+      const filters: Filters = {
+        sources: [],
+        systems: [],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByRole } = render(<SourceAndSystemFilter />);
+
+      const component = getByRole('listbox');
+      expect(component).toHaveTextContent('Sources and systems...');
+    });
+  });
+
+  describe('selection options', () => {
+    describe('with no registered systems', () => {
+      beforeEach(() => {
+        callSetUseApplicationData({
+          connections: [
+            ['source1', true],
+            ['source2', true],
+            ['source3', false],
+          ],
+        });
+        setupMockSystems([]);
+      });
+
+      it('should not display source options if there are no sources', async () => {
+        callSetUseApplicationData({
+          connections: [],
+        });
+
+        const { queryByTestId } = await openDropDown();
+
+        const sourceItems = queryByTestId('source-items');
+
+        expect(sourceItems).not.toBeInTheDocument();
+      });
+
+      it('should display "no sources" message if there are no sources', async () => {
+        callSetUseApplicationData({
+          connections: [],
+        });
+
+        const { getByTestId } = await openDropDown();
+
+        const noSourcesMessage = getByTestId('no-sources');
+
+        expect(noSourcesMessage).toBeVisible();
+        expect(noSourcesMessage).toHaveTextContent('No sources connected...');
+      });
+
+      it('should display source options', async () => {
+        const { getByTestId } = await openDropDown();
+
+        const sourceItems = getByTestId('source-items');
+
+        expect(sourceItems).toBeVisible();
+      });
+
+      it('should not display system options', async () => {
+        const { queryByTestId } = await openDropDown();
+
+        const systemItems = queryByTestId('system-items');
+
+        expect(systemItems).not.toBeInTheDocument();
+      });
+
+      it('should not display source options heading', async () => {
+        const { queryByTestId } = await openDropDown();
+
+        const sourceItemsHeading = queryByTestId('source-items-heading');
+
+        expect(sourceItemsHeading).not.toBeInTheDocument();
+      });
+
+      it('should not display source / system divider', async () => {
+        const { queryByTestId } = await openDropDown();
+
+        const itemsDivider = queryByTestId('items-divider');
+
+        expect(itemsDivider).not.toBeInTheDocument();
+      });
+
+      it('should display each source as an option', async () => {
+        const { getAllByTestId } = await openDropDown();
+
+        const sourceItems = getAllByTestId('source-item');
+
+        expect(sourceItems).toHaveLength(3);
+        expect(sourceItems.at(0)!).toHaveTextContent('source1');
+        expect(sourceItems.at(1)!).toHaveTextContent('source2');
+        expect(sourceItems.at(2)!).toHaveTextContent('source3');
+      });
+
+      it('should display active status for each source', async () => {
+        const { getAllByTestId } = await openDropDown();
+
+        const sourceItems = getAllByTestId('source-item');
+
+        expect(within(sourceItems.at(0)!).getByTestId('status')).toHaveClass('bg-green-300');
+        expect(within(sourceItems.at(1)!).getByTestId('status')).toHaveClass('bg-green-300');
+        expect(within(sourceItems.at(2)!).getByTestId('status')).toHaveClass('bg-red-300');
+      });
+    });
+
+    describe('with some registered systems', () => {
+      beforeEach(() => {
+        callSetUseApplicationData({
+          connections: [
+            ['source1', true],
+            ['source2', true],
+            ['source3', false],
+          ],
+        });
+        setupMockSystems(mockSystems);
+      });
+
+      it('should display source options', async () => {
+        const { getByTestId } = await openDropDown();
+
+        const sourceItems = getByTestId('source-items');
+
+        expect(sourceItems).toBeVisible();
+      });
+
+      it('should display system options', async () => {
+        const { getByTestId } = await openDropDown();
+
+        const systemItems = getByTestId('system-items');
+
+        expect(systemItems).toBeVisible();
+      });
+
+      it('should display source options heading', async () => {
+        const { getByTestId } = await openDropDown();
+
+        const sourceItemsHeading = getByTestId('source-items-heading');
+
+        expect(sourceItemsHeading).toBeVisible();
+      });
+
+      it('should not display source / system divider', async () => {
+        const { getByTestId } = await openDropDown();
+
+        const itemsDivider = getByTestId('items-divider');
+
+        expect(itemsDivider).toBeVisible();
+      });
+
+      it('should display each source as an option', async () => {
+        const { getAllByTestId } = await openDropDown();
+
+        const sourceItems = getAllByTestId('source-item');
+
+        expect(sourceItems).toHaveLength(3);
+        expect(sourceItems.at(0)!).toHaveTextContent('source1');
+        expect(sourceItems.at(1)!).toHaveTextContent('source2');
+        expect(sourceItems.at(2)!).toHaveTextContent('source3');
+      });
+
+      it('should display active status for each source', async () => {
+        const { getAllByTestId } = await openDropDown();
+
+        const sourceItems = getAllByTestId('source-item');
+
+        expect(within(sourceItems.at(0)!).getByTestId('status')).toHaveClass('bg-green-300');
+        expect(within(sourceItems.at(1)!).getByTestId('status')).toHaveClass('bg-green-300');
+        expect(within(sourceItems.at(2)!).getByTestId('status')).toHaveClass('bg-red-300');
+      });
+
+      it('should display each system as an option', async () => {
+        const { getAllByTestId } = await openDropDown();
+
+        const sourceItems = getAllByTestId('system-item');
+
+        expect(sourceItems).toHaveLength(mockSystems.length);
+        mockSystems.forEach((mockSystem, idx) => {
+          expect(sourceItems.at(idx)!).toHaveTextContent(mockSystem.name);
+        });
+      });
+    });
+  });
+
+  describe('making selections', () => {
+    describe('source selection', () => {
+      it('should call `setFilters` with updated sources when adding a new source', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: [],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('source-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: ['source1'],
+          systems: [],
+          searchTerm: '',
+        });
+      });
+
+      it('should add to existing sources when new sources selected', async () => {
+        const filters: Filters = {
+          sources: ['source1'],
+          systems: [],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('source-item');
+
+          const secondItem = listItems.at(1)!;
+          await userEvent.click(secondItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: ['source1', 'source2'],
+          systems: [],
+          searchTerm: '',
+        });
+      });
+
+      it('should remove source from filters when existing source selected', async () => {
+        const filters: Filters = {
+          sources: ['source1', 'source2'],
+          systems: [],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('source-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: ['source2'],
+          systems: [],
+          searchTerm: '',
+        });
+      });
+
+      it('should not alter systems or search term', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: [mockSystems[0].name],
+          searchTerm: 'search term',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('source-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: ['source1'],
+          systems: [mockSystems[0].name],
+          searchTerm: 'search term',
+        });
+      });
+    });
+
+    describe('system selection', () => {
+      it('should call `setFilters` with updated systems when adding a new system', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: [],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('system-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: [],
+          systems: [mockSystems[0].name],
+          searchTerm: '',
+        });
+      });
+
+      it('should add to existing sources when new sources selected', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: [mockSystems[0].name],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('system-item');
+
+          const secondItem = listItems.at(1)!;
+          await userEvent.click(secondItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: [],
+          systems: [mockSystems[0].name, mockSystems[1].name],
+          searchTerm: '',
+        });
+      });
+
+      it('should remove source from filters when existing source selected', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: [mockSystems[0].name, mockSystems[1].name],
+          searchTerm: '',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('system-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: [],
+          systems: [mockSystems[1].name],
+          searchTerm: '',
+        });
+      });
+
+      it('should not alter systems or search term', async () => {
+        const filters: Filters = {
+          sources: ['source1'],
+          systems: [],
+          searchTerm: 'search term',
+        };
+        setUseApplicationData({ filters });
+
+        const { getAllByTestId } = await openDropDown();
+
+        await act(async () => {
+          const listItems = getAllByTestId('system-item');
+
+          const firstItem = listItems.at(0)!;
+          await userEvent.click(firstItem);
+        });
+
+        assertSetFilterUpdate(filters, {
+          sources: ['source1'],
+          systems: [mockSystems[0].name],
+          searchTerm: 'search term',
+        });
+      });
+    });
+  });
+
+  describe('clearing selections', () => {
+    it('should not display clear button when no selection is made', () => {
+      const filters: Filters = {
+        sources: [],
+        systems: [],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { queryByTestId } = render(<SourceAndSystemFilter />);
+
+      const clearButton = queryByTestId('input-clear');
+      expect(clearButton).not.toBeInTheDocument();
+    });
+
+    it('should display clear button when a selection is made', async () => {
+      const filters: Filters = {
+        sources: ['source1'],
+        systems: [mockSystems[0].name],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByTestId } = render(<SourceAndSystemFilter />);
+
+      const clearButton = getByTestId('input-clear');
+      expect(clearButton).toHaveTextContent('Mock HiX component');
+    });
+
+    it('should call `setFilters` with empty source and systems when clicking the clear button', async () => {
+      const filters: Filters = {
+        sources: ['source1'],
+        systems: [mockSystems[0].name],
+        searchTerm: '',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByTestId } = render(<SourceAndSystemFilter />);
+
+      await act(async () => {
+        const clearButton = getByTestId('input-clear');
+        await userEvent.click(clearButton);
+      });
+
+      assertSetFilterUpdate(filters, {
+        sources: [],
+        systems: [],
+        searchTerm: '',
+      });
+    });
+
+    it('should not affect search term when clicking the clear button', async () => {
+      const filters: Filters = {
+        sources: ['source1'],
+        systems: [mockSystems[0].name],
+        searchTerm: 'search term',
+      };
+      setUseApplicationData({ filters });
+
+      const { getByTestId } = render(<SourceAndSystemFilter />);
+
+      await act(async () => {
+        const clearButton = getByTestId('input-clear');
+        await userEvent.click(clearButton);
+      });
+
+      assertSetFilterUpdate(filters, {
+        sources: [],
+        systems: [],
+        searchTerm: 'search term',
+      });
+    });
+  });
+
+  describe('clicking away', () => {
+    it('should hide options when clicking away somewhere else in the document', async () => {
+      const { container, getByRole, queryByTestId } = render(<SourceAndSystemFilter />);
+      const sourceAndSystemFilter = getByRole('listbox');
+
+      await act(async () => {
+        await userEvent.click(sourceAndSystemFilter);
+      });
+
+      const listItemsBefore = queryByTestId('filter-options');
+      expect(listItemsBefore).toBeVisible();
+
+      await act(async () => {
+        await userEvent.click(container);
+      });
+
+      const listItemsAfter = queryByTestId('filter-options');
+      expect(listItemsAfter).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/webui/src/components/ui/SourceAndSystemFilter.tsx
+++ b/packages/webui/src/components/ui/SourceAndSystemFilter.tsx
@@ -1,0 +1,179 @@
+import { Ref, RefObject, forwardRef, useRef, useState } from 'react';
+import { HiCheck, HiOutlineFilter, HiX } from 'react-icons/hi';
+
+import useApplication from '@/hooks/useApplication';
+import useClickAway from '@/hooks/useClickAway';
+import { getDefaultSystem, getRegisteredSystems } from '@/systems/registration';
+import { tw } from '@/utils';
+
+type SourceAndSystemFilterProps = React.HTMLAttributes<HTMLDivElement>;
+
+function SourceAndSystemFilter({ className, ...props }: SourceAndSystemFilterProps, ref: Ref<HTMLDivElement>) {
+  const dropDownFieldRef = useRef<HTMLDivElement>(null);
+  const finalRef = (ref || dropDownFieldRef) as RefObject<HTMLDivElement>;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const { connections, filters, setFilters } = useApplication();
+  useClickAway(finalRef, () => setIsOpen(false));
+
+  function handleSourceSelection(name: string) {
+    setFilters(curr => {
+      const newSources = curr.sources.includes(name) ? curr.sources.filter(x => x !== name) : [...curr.sources, name];
+      return {
+        ...curr,
+        sources: newSources,
+      };
+    });
+  }
+
+  function handleSystemSelection(name: string) {
+    setFilters(curr => {
+      const newSystems = curr.systems.includes(name) ? curr.systems.filter(x => x !== name) : [...curr.systems, name];
+      return {
+        ...curr,
+        systems: newSystems,
+      };
+    });
+  }
+
+  function clearSelection() {
+    setFilters(curr => ({
+      ...curr,
+      sources: [],
+      systems: [],
+    }));
+  }
+
+  const defaultIcon = getDefaultSystem().getIconUri();
+  const systems = getRegisteredSystems();
+  const hasFilters = filters.sources.length + filters.systems.length > 0;
+
+  const hasSources = connections.length > 0;
+  const hasSystems = systems.length > 0;
+
+  const placeholder = hasSystems ? 'Sources and systems...' : 'Sources...';
+
+  const dropDownOptionsClasses = hasSystems
+    ? 'rounded-tr-none w-[45rem] grid-cols-[1fr_1px_1fr] gap-4 p-4'
+    : 'rounded-t-none w-full grid-cols-1';
+
+  const currentSelections = [];
+  if (filters.sources.length > 0) {
+    currentSelections.push(`${filters.sources.length} source${filters.sources.length > 1 ? 's' : ''}`);
+  }
+  if (filters.systems.length > 0) {
+    currentSelections.push(`${filters.systems.length} system${filters.systems.length > 1 ? 's' : ''}`);
+  }
+
+  return (
+    <div ref={finalRef} className={tw('flex input-container self-stretch', className)} {...props}>
+      <div className="group w-full z-50">
+        <div
+          role="listbox"
+          data-test-item="filters"
+          className={tw(
+            'cursor-pointer relative flex items-center input-container input pl-9',
+            isOpen && 'bg-white rounded-b-none hover:shadow-none',
+          )}
+          onClick={() => setIsOpen(curr => !curr)}
+        >
+          <HiOutlineFilter />
+          {!hasFilters ? (
+            <span className="opacity-50">{placeholder}</span>
+          ) : (
+            <>
+              <span data-test-id="selection-summary">{currentSelections.join(', ')}</span>
+              <span data-test-id="input-clear" className={tw('input-clear', isOpen && 'flex')} onClick={clearSelection}>
+                <HiX />
+              </span>
+            </>
+          )}
+        </div>
+        {isOpen && (
+          <div
+            data-test-id="filter-options"
+            className={tw(
+              'absolute top-full right-0 select-none',
+              'grid grid-rows-1 input bg-white',
+              dropDownOptionsClasses,
+            )}
+          >
+            <div>
+              {hasSystems && (
+                <div data-test-id="source-items-heading" className="font-bold p-2">
+                  Sources
+                </div>
+              )}
+              {hasSources ? (
+                <ul data-test-id="source-items" className="flex flex-col gap-1">
+                  {connections.map(([name, isActive]) => {
+                    const isSelected = filters.sources.includes(name);
+                    const statusColor = isActive ? 'bg-green-300' : 'bg-red-300';
+                    return (
+                      <li
+                        key={name}
+                        data-test-id="source-item"
+                        className="cursor-pointer"
+                        onClick={() => handleSourceSelection(name)}
+                      >
+                        <span
+                          className={tw(
+                            'transition-all p-2 flex flex-row items-center rounded bg-white border border-transparent hover:bg-slate-100',
+                            isSelected && 'bg-slate-100 border-slate-200 hover:bg-slate-50',
+                          )}
+                        >
+                          <span data-test-id="status" className={tw('w-3 h-3 mr-2 rounded-full', statusColor)}></span>
+                          <span className="flex-1">{name}</span>
+                          {isSelected && <HiCheck className="flex-0 w-6 h-6" />}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <span data-test-id="no-sources" className="opacity-50 p-2 italic">
+                  No sources connected...
+                </span>
+              )}
+            </div>
+            {hasSystems && <div data-test-id="items-divider" className="w-px bg-slate-200"></div>}
+            {hasSystems && (
+              <div>
+                <div data-test-id="system-items-heading" className="font-bold p-2">
+                  Systems
+                </div>
+                <ul data-test-id="system-items" className="flex flex-col gap-1">
+                  {systems.map(system => {
+                    const isSelected = filters.systems.includes(system.name);
+                    const icon = system.getIconUri?.() ?? defaultIcon;
+                    return (
+                      <li
+                        key={system.name}
+                        data-test-id="system-item"
+                        className="cursor-pointer"
+                        onClick={() => handleSystemSelection(system.name)}
+                      >
+                        <span
+                          className={tw(
+                            'transition-all p-2 flex flex-row items-center rounded bg-white border border-transparent hover:bg-slate-100',
+                            isSelected && 'bg-slate-100 border-slate-200 hover:bg-slate-50',
+                          )}
+                        >
+                          {icon && <img src={icon} alt="" className="flex-0 mr-2 w-6 object-contain" />}
+                          <span className="flex-1">{system.name}</span>
+                          {isSelected && <HiCheck className="flex-0  w-6 h-6" />}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default forwardRef(SourceAndSystemFilter);

--- a/packages/webui/src/components/ui/TraceList.test.tsx
+++ b/packages/webui/src/components/ui/TraceList.test.tsx
@@ -62,8 +62,8 @@ describe('TraceList', () => {
       { status: 'connecting', useApplicationState: { connecting: true, connected: false }, message: 'Connecting...' },
       {
         status: 'connected',
-        useApplicationState: { connecting: false, connected: true, port: 1234 },
-        message: 'Connected to ws://127.0.0.1:1234',
+        useApplicationState: { connecting: false, connected: true },
+        message: 'Listening for traces...',
       },
       {
         status: 'failed to connect',

--- a/packages/webui/src/components/ui/TraceList.tsx
+++ b/packages/webui/src/components/ui/TraceList.tsx
@@ -104,7 +104,7 @@ export default function TraceList({ autoScroll: initialAutoScroll = true, classN
   ];
 
   const [Icon, message] = connected
-    ? [HiStatusOnline, `Connected to ws://127.0.0.1:${port}/ ...`]
+    ? [HiStatusOnline, `Listening for traces...`]
     : connecting
     ? [HiOutlineLightningBolt, 'Connecting...']
     : [HiOutlineEmojiSad, 'Unable to connect'];

--- a/packages/webui/src/components/ui/TraceList.tsx
+++ b/packages/webui/src/components/ui/TraceList.tsx
@@ -26,7 +26,7 @@ type TraceListProps = React.HTMLAttributes<HTMLElement> & {
 };
 
 export default function TraceList({ autoScroll: initialAutoScroll = true, className }: TraceListProps) {
-  const { port, connected, connecting, traces, selectedTraceId, newestTraceId, setSelectedTrace } = useApplication();
+  const { connected, connecting, traces, selectedTraceId, newestTraceId, setSelectedTrace } = useApplication();
   const [autoScroll, setAutoScroll] = useState(initialAutoScroll);
 
   const data = [...traces.values()];

--- a/packages/webui/src/context/ApplicationContext.test.tsx
+++ b/packages/webui/src/context/ApplicationContext.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { ReactElement, useContext, useEffect } from 'react';
 
 import CollectorClient from '@/collector/CollectorClient';
-import { ApplicationContext } from '@/hooks/useApplication';
-import { setupMockSystems } from '@/testing/mockSystems';
+import { ApplicationContext, Filters } from '@/hooks/useApplication';
+import { mockSystems, setupMockSystems } from '@/testing/mockSystems';
 import mockTraces, { mockTraceCollection } from '@/testing/mockTraces';
 import { Trace } from '@/types';
 
@@ -320,12 +320,15 @@ describe('ApplicationContext', () => {
     });
 
     describe('filterTraces', () => {
-      it('should filter traces by system', async () => {
-        const systems = ['OddNumbers'];
-        const value = '';
+      it('should filter traces by source', async () => {
+        const filters: Filters = {
+          sources: ['web'],
+          systems: [],
+          searchTerm: '',
+        };
 
         function TestComponent() {
-          const { traces, filterTraces } = useContext(ApplicationContext);
+          const { traces, setFilters } = useContext(ApplicationContext);
 
           return (
             <>
@@ -336,7 +339,50 @@ describe('ApplicationContext', () => {
                   </li>
                 ))}
               </ul>
-              <button data-test-id="button" onClick={() => filterTraces(systems, value)}>
+              <button data-test-id="button" onClick={() => setFilters(filters)}>
+                Button
+              </button>
+            </>
+          );
+        }
+
+        const { getByTestId, getAllByTestId } = renderComponentInProvider(<TestComponent />);
+
+        await act(async () => {
+          const button = getByTestId('button');
+          await userEvent.click(button);
+        });
+
+        const traces = getAllByTestId('trace');
+
+        const expectedTraces = mockTraces.filter(x => x.serviceName === 'web');
+
+        expect(traces).toHaveLength(expectedTraces.length);
+        expectedTraces.forEach((trace, idx) => {
+          expect(traces.at(idx)).toHaveTextContent(traceString(trace));
+        });
+      });
+
+      it('should filter traces by system', async () => {
+        const filters: Filters = {
+          sources: [],
+          systems: ['OddNumbers'],
+          searchTerm: '',
+        };
+
+        function TestComponent() {
+          const { traces, setFilters } = useContext(ApplicationContext);
+
+          return (
+            <>
+              <ul>
+                {[...traces.entries()].map(([id, trace]) => (
+                  <li data-test-id="trace" key={id}>
+                    {traceString(trace)}
+                  </li>
+                ))}
+              </ul>
+              <button data-test-id="button" onClick={() => setFilters(filters)}>
                 Button
               </button>
             </>
@@ -361,11 +407,14 @@ describe('ApplicationContext', () => {
       });
 
       it('should filter traces by value', async () => {
-        const systems: string[] = [];
-        const value = 'data.restserver';
+        const filters: Filters = {
+          sources: [],
+          systems: [],
+          searchTerm: 'data.restserver',
+        };
 
         function TestComponent() {
-          const { traces, filterTraces } = useContext(ApplicationContext);
+          const { traces, setFilters } = useContext(ApplicationContext);
 
           return (
             <>
@@ -376,7 +425,7 @@ describe('ApplicationContext', () => {
                   </li>
                 ))}
               </ul>
-              <button data-test-id="button" onClick={() => filterTraces(systems, value)}>
+              <button data-test-id="button" onClick={() => setFilters(filters)}>
                 Button
               </button>
             </>
@@ -392,7 +441,7 @@ describe('ApplicationContext', () => {
 
         const traces = getAllByTestId('trace');
 
-        const expectedTraces = mockTraces.filter(x => x.http?.host.includes(value));
+        const expectedTraces = mockTraces.filter(x => x.http?.host.includes('data.restserver'));
 
         expect(traces).toHaveLength(expectedTraces.length);
         expectedTraces.forEach((trace, idx) => {
@@ -401,11 +450,14 @@ describe('ApplicationContext', () => {
       });
 
       it('should show all traces if no systems or value have been set', async () => {
-        const systems: string[] = [];
-        const value = '';
+        const filters: Filters = {
+          sources: [],
+          systems: [],
+          searchTerm: '',
+        };
 
         function TestComponent() {
-          const { traces, filterTraces } = useContext(ApplicationContext);
+          const { traces, setFilters } = useContext(ApplicationContext);
 
           return (
             <>
@@ -416,7 +468,7 @@ describe('ApplicationContext', () => {
                   </li>
                 ))}
               </ul>
-              <button data-test-id="button" onClick={() => filterTraces(systems, value)}>
+              <button data-test-id="button" onClick={() => setFilters(filters)}>
                 Button
               </button>
             </>

--- a/packages/webui/src/context/ApplicationContext.test.tsx
+++ b/packages/webui/src/context/ApplicationContext.test.tsx
@@ -4,7 +4,7 @@ import { ReactElement, useContext, useEffect } from 'react';
 
 import CollectorClient from '@/collector/CollectorClient';
 import { ApplicationContext, Filters } from '@/hooks/useApplication';
-import { mockSystems, setupMockSystems } from '@/testing/mockSystems';
+import { setupMockSystems } from '@/testing/mockSystems';
 import mockTraces, { mockTraceCollection } from '@/testing/mockTraces';
 import { Trace } from '@/types';
 

--- a/packages/webui/src/context/ApplicationContext.tsx
+++ b/packages/webui/src/context/ApplicationContext.tsx
@@ -79,7 +79,10 @@ export default function ApplicationContextProvider({ children }: React.HTMLAttri
     port: collectorRef.current?.port ?? 0,
     connecting: collectorRef.current?.connecting ?? true,
     connected: collectorRef.current?.connected ?? false,
-    connections: collectorRef.current?.connections ?? [],
+    allConnections: collectorRef.current?.connections ?? [],
+    get activeConnections() {
+      return (collectorRef.current?.connections ?? []).filter(([_, isActive]) => isActive === true);
+    },
     get traces() {
       if (!collectorRef.current) return new Map();
       if (!filter || !hasFilters()) return collectorRef.current?.traces;

--- a/packages/webui/src/context/ApplicationContext.tsx
+++ b/packages/webui/src/context/ApplicationContext.tsx
@@ -79,6 +79,7 @@ export default function ApplicationContextProvider({ children }: React.HTMLAttri
     port: collectorRef.current?.port ?? 0,
     connecting: collectorRef.current?.connecting ?? true,
     connected: collectorRef.current?.connected ?? false,
+    connections: collectorRef.current?.connections ?? [],
     get traces() {
       if (!collectorRef.current) return new Map();
       if (!filter || !hasFilters()) return collectorRef.current?.traces;

--- a/packages/webui/src/hooks/useApplication.test.ts
+++ b/packages/webui/src/hooks/useApplication.test.ts
@@ -15,11 +15,13 @@ describe('useApplication', () => {
       'connecting',
       'connected',
       'traces',
+      'connections',
       'selectedTraceId',
       'setSelectedTrace',
       'getSelectedTrace',
       'clearSelectedTrace',
-      'filterTraces',
+      'filters',
+      'setFilters',
       'clearTraces',
     ].forEach(propName => expect(context).toHaveProperty(propName));
   });

--- a/packages/webui/src/hooks/useApplication.ts
+++ b/packages/webui/src/hooks/useApplication.ts
@@ -1,3 +1,4 @@
+import { ConnectionStatusData } from '@envyjs/core';
 import { createContext, useContext } from 'react';
 
 import CollectorClient from '@/collector/CollectorClient';
@@ -8,7 +9,8 @@ export type ApplicationContextData = {
   port: number;
   connecting: boolean;
   connected: boolean;
-  connections: string[];
+  allConnections: ConnectionStatusData;
+  activeConnections: ConnectionStatusData;
   traces: Traces;
   selectedTraceId?: string;
   newestTraceId?: string;

--- a/packages/webui/src/hooks/useApplication.ts
+++ b/packages/webui/src/hooks/useApplication.ts
@@ -8,6 +8,7 @@ export type ApplicationContextData = {
   port: number;
   connecting: boolean;
   connected: boolean;
+  connections: string[];
   traces: Traces;
   selectedTraceId?: string;
   newestTraceId?: string;

--- a/packages/webui/src/hooks/useApplication.ts
+++ b/packages/webui/src/hooks/useApplication.ts
@@ -1,23 +1,29 @@
 import { ConnectionStatusData } from '@envyjs/core';
-import { createContext, useContext } from 'react';
+import { Dispatch, SetStateAction, createContext, useContext } from 'react';
 
 import CollectorClient from '@/collector/CollectorClient';
 import { Trace, Traces } from '@/types';
+
+export type Filters = {
+  sources: string[];
+  systems: string[];
+  searchTerm: string;
+};
 
 export type ApplicationContextData = {
   collector: CollectorClient | undefined;
   port: number;
   connecting: boolean;
   connected: boolean;
-  allConnections: ConnectionStatusData;
-  activeConnections: ConnectionStatusData;
+  connections: ConnectionStatusData;
   traces: Traces;
   selectedTraceId?: string;
   newestTraceId?: string;
   getSelectedTrace: () => Trace | undefined;
   setSelectedTrace: (id: string) => void;
   clearSelectedTrace: () => void;
-  filterTraces: (systems: string[], value: string) => void;
+  filters: Filters;
+  setFilters: Dispatch<SetStateAction<Filters>>;
   clearTraces: () => void;
 };
 

--- a/packages/webui/src/testing/mockSystems.ts
+++ b/packages/webui/src/testing/mockSystems.ts
@@ -5,7 +5,7 @@ import { System, Trace, TraceContext } from '@/types';
 
 jest.mock('@/systems/registration');
 
-const mockSystems: System<unknown>[] = [
+export const mockSystems: System<unknown>[] = [
   new (class implements System<{ id: string; foo: string }> {
     name = 'Foo';
     isMatch(trace: Trace) {
@@ -133,7 +133,7 @@ const mockDefaultSystem = new (class implements System<null> {
   }
 })();
 
-export function setupMockSystems() {
-  jest.mocked(getRegisteredSystems).mockReturnValue(mockSystems);
+export function setupMockSystems(registeredSystems = mockSystems) {
+  jest.mocked(getRegisteredSystems).mockReturnValue(registeredSystems);
   jest.mocked(getDefaultSystem).mockReturnValue(mockDefaultSystem);
 }

--- a/packages/webui/src/testing/mockUseApplication.ts
+++ b/packages/webui/src/testing/mockUseApplication.ts
@@ -2,12 +2,14 @@ import useApplication, { ApplicationContextData } from '@/hooks/useApplication';
 
 jest.mock('@/hooks/useApplication');
 
-const defaults = {
+const defaults: ApplicationContextData = {
   collector: undefined,
   port: 9999,
   connecting: true,
   connected: false,
   traces: new Map(),
+  allConnections: [],
+  activeConnections: [],
   getSelectedTrace: () => void 0,
   setSelectedTrace: () => void 0,
   clearSelectedTrace: () => void 0,

--- a/packages/webui/src/testing/mockUseApplication.ts
+++ b/packages/webui/src/testing/mockUseApplication.ts
@@ -8,12 +8,16 @@ const defaults: ApplicationContextData = {
   connecting: true,
   connected: false,
   traces: new Map(),
-  allConnections: [],
-  activeConnections: [],
+  connections: [],
   getSelectedTrace: () => void 0,
   setSelectedTrace: () => void 0,
   clearSelectedTrace: () => void 0,
-  filterTraces: () => void 0,
+  filters: {
+    sources: [],
+    systems: [],
+    searchTerm: '',
+  },
+  setFilters: () => void 0,
   clearTraces: () => void 0,
 };
 


### PR DESCRIPTION
## What does this PR do?

- Updates the `@envyjs/webui` collector to report client connections (from the `@envyjs/node` and `@envyjs/web` senders) to the web viewer.
- Repurposes the systems filter to do the following in addition to listing and allow filtering by system:
  - Display connected sources
  - Show active (connection) status of connected sources
  - Allow filtering of traces by source
- Renames the "search" field to say "search term..." rather than "filter...", since filtering is what we are doing in this repurposed source/system dropdown.
- Updated the debug menu to have an icon and a button width independent of the menu width

## Screenshots

**The new source/system filter:**

![image](https://github.com/FormidableLabs/envy/assets/17857833/a9486681-278d-4a6c-841e-dacfad1f47be)

**With a source selected:**

![image](https://github.com/FormidableLabs/envy/assets/17857833/18d1c4da-5ef7-422e-b0a1-6e7282ed0784)

**With a source and a system selected:**

![image](https://github.com/FormidableLabs/envy/assets/17857833/d1488c4c-18b4-43fd-b016-688dac582da3)

**With a source having become disconnected:**

![image](https://github.com/FormidableLabs/envy/assets/17857833/739eada3-095a-4244-bcda-8ea71412537c)
