### PR TITLE
Fix tracing of App router components

### DIFF
--- a/.changeset/tall-badgers-dress.md
+++ b/.changeset/tall-badgers-dress.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/nextjs': minor
+---
+
+Fix RSC tracing

--- a/packages/nextjs/src/loaders/page.loader.ts
+++ b/packages/nextjs/src/loaders/page.loader.ts
@@ -1,0 +1,8 @@
+export default function envyPageLoader(this: any, source: string) {
+  const options = this.getOptions();
+  const injectedCode = `
+    const { enableTracing } = require('@envyjs/nextjs');
+    enableTracing(${JSON.stringify(options)});
+  `;
+  return `${injectedCode}\n${source}`;
+}


### PR DESCRIPTION
Wrap react server component pages with a loader for Envy/nextjs and fix a bug where entry points might be null during compilation.