### PR TITLE
Improve detection and display of graphql requests

### DIFF
--- a/.changeset/sixty-suns-hear.md
+++ b/.changeset/sixty-suns-hear.md
@@ -1,0 +1,6 @@
+---
+'@envyjs/webui': patch
+'@envyjs/core': patch
+---
+
+Improve anonymous graphql query display

--- a/packages/core/src/middleware/graphql.test.ts
+++ b/packages/core/src/middleware/graphql.test.ts
@@ -76,6 +76,27 @@ describe('graphql', () => {
     });
   });
 
+  it('should parse an anonymous query from a GET request', () => {
+    const event: Event = {
+      id: '2',
+      timestamp: 123333,
+      http: {
+        method: 'GET',
+        host: 'bobo.io',
+        url: 'http://bobo.io/?query={%20hello%20{%20value%20}%20}',
+        path: '',
+        port: 80,
+        requestHeaders: {},
+      },
+    };
+
+    const output = Graphql(event, { serviceName: 'test-name' });
+    expect(output.graphql).toEqual({
+      operationType: 'query',
+      query: '{ hello { value } }',
+    });
+  });
+
   it('should parse the operation name and variables from a GET request', () => {
     const event: Event = {
       id: '2',
@@ -98,6 +119,32 @@ describe('graphql', () => {
       variables: {
         test: 'value',
       },
+    });
+  });
+
+  it('should parse the query from an anonymous POST request', () => {
+    const event: Event = {
+      id: '2',
+      timestamp: 123333,
+      http: {
+        method: 'POST',
+        host: 'bobo.io',
+        url: 'http://bobo.io/',
+        path: '',
+        port: 80,
+        requestHeaders: {
+          'content-type': 'application/json',
+        },
+        requestBody: JSON.stringify({
+          query: '{ hello { value } }',
+        }),
+      },
+    };
+
+    const output = Graphql(event, { serviceName: 'test-name' });
+    expect(output.graphql).toEqual({
+      operationType: 'query',
+      query: '{ hello { value } }',
     });
   });
 

--- a/packages/core/src/middleware/graphql.ts
+++ b/packages/core/src/middleware/graphql.ts
@@ -39,11 +39,11 @@ function mapGraphqlData({
   query?: string | null;
   variables?: Record<any, any>;
 }): GraphqlRequest | undefined {
-  const matcher = /^(mutation|query)/g;
+  const matcher = /^(mutation|query)?\s*([a-zA-Z]*)?\s*{?\(?/g;
   const match = query && matcher.exec(query.trim());
   if (match) {
     return {
-      operationType: match[1] as GraphqlRequest['operationType'],
+      operationType: (match[1] || 'query') as GraphqlRequest['operationType'],
       operationName: operationName || undefined,
       query,
       variables: variables || undefined,

--- a/packages/webui/src/systems/GraphQL.tsx
+++ b/packages/webui/src/systems/GraphQL.tsx
@@ -30,8 +30,13 @@ export default class GraphQLSystem implements System<GraphQLData> {
   getTraceRowData({ data }: TraceContext<GraphQLData>) {
     const { operationType, operationName } = data;
 
+    let rowData = `GQL ${operationType}`;
+    if (operationName) {
+      rowData += `: ${operationName}`;
+    }
+
     return {
-      data: `GQL ${operationType}: ${operationName}`,
+      data: rowData,
     };
   }
 


### PR DESCRIPTION
Anonymous queries with the operation type or name were not properly detected. This PR adds better regex support for those type of queries.

Fixes: #115 
Fixes: #116