### PR TITLE
Add HTTP Request State for internal tracking

### DIFF
--- a/.changeset/smooth-roses-sort.md
+++ b/.changeset/smooth-roses-sort.md
@@ -1,0 +1,7 @@
+---
+'@envyjs/webui': patch
+'@envyjs/core': patch
+'@envyjs/node': patch
+---
+
+Add http request state for tracking

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -1,5 +1,5 @@
 import { Event } from './event';
-import { HttpRequest } from './http';
+import { HttpRequest, HttpRequestState } from './http';
 
 // TODO: the types in this file are from lib/dom
 // we need to replace them with a platform agnostic version
@@ -36,6 +36,7 @@ export function fetchRequestToEvent(id: string, input: RequestInfo | URL, init?:
     parentId: undefined,
     timestamp: Date.now(),
     http: {
+      state: HttpRequestState.Sent,
       method: (init?.method ?? 'GET') as HttpRequest['method'],
       host: url.host,
       port: parseInt(url.port, 10),
@@ -53,6 +54,7 @@ export async function fetchResponseToEvent(req: Event, response: Response): Prom
 
     http: {
       ...req.http!,
+      state: HttpRequestState.Received,
       httpVersion: response.type,
       statusCode: response.status,
       statusMessage: response.statusText,

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,3 +1,37 @@
+export enum HttpRequestState {
+  /**
+   * Request has been sent to the endpoint
+   */
+  Sent = 'sent',
+
+  /**
+   * A response has been received from the endpoint
+   */
+  Received = 'received',
+
+  /**
+   * The request was aborted by the caller, regardless
+   * of whether a response was received or not
+   */
+  Aborted = 'aborted',
+
+  /**
+   * The request was blocked by the client due to CORS
+   */
+  Blocked = 'blocked',
+
+  /**
+   * The request timed out
+   */
+  Timeout = 'timeout',
+
+  /**
+   * There was a network error sending the request.
+   * Note, this is not the same as a 4|5XX response.
+   */
+  Error = 'error',
+}
+
 export interface HttpRequest {
   /**
    * Request duration in milliseconds
@@ -48,6 +82,11 @@ export interface HttpRequest {
    * The normalized http request headers (lowercase)
    */
   requestHeaders: Record<string, undefined | string | string[]>;
+
+  /**
+   * The state of the request
+   */
+  state: HttpRequestState;
 
   /**
    * The HTTP status code

--- a/packages/core/src/middleware/graphql.test.ts
+++ b/packages/core/src/middleware/graphql.test.ts
@@ -1,4 +1,5 @@
 import { Event } from '../event';
+import { HttpRequestState } from '../http';
 
 import { Graphql } from './graphql';
 
@@ -17,6 +18,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'GET',
         host: 'bobo.io',
         url: 'http://bobo.io?query=mushmush',
@@ -35,6 +37,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'POST',
         host: 'bobo.io',
         url: 'http://bobo.io/',
@@ -60,6 +63,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'GET',
         host: 'bobo.io',
         url: 'http://bobo.io/?query=query%20{%20hello%20{%20value%20}%20}',
@@ -81,6 +85,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'GET',
         host: 'bobo.io',
         url: 'http://bobo.io/?query={%20hello%20{%20value%20}%20}',
@@ -102,6 +107,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'GET',
         host: 'bobo.io',
         url: 'http://bobo.io/?query=query%20GreetingQuery%20{%20hello%20{%20value%20}%20}&operationName=GreetingQuery&variables=%7B%20%22test%22%3A%20%22value%22%20%7D',
@@ -127,6 +133,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'POST',
         host: 'bobo.io',
         url: 'http://bobo.io/',
@@ -153,6 +160,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'POST',
         host: 'bobo.io',
         url: 'http://bobo.io/',
@@ -176,6 +184,7 @@ describe('graphql', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         method: 'POST',
         host: 'bobo.io',
         url: 'http://bobo.io/',

--- a/packages/core/src/middleware/sanity.test.ts
+++ b/packages/core/src/middleware/sanity.test.ts
@@ -1,4 +1,5 @@
 import { Event } from '../event';
+import { HttpRequestState } from '../http';
 
 import { Sanity } from './sanity';
 
@@ -55,6 +56,7 @@ describe('sanity', () => {
       id: '2',
       timestamp: 123333,
       http: {
+        state: HttpRequestState.Sent,
         host: 'test.sanity.io',
         method: 'POST',
         requestHeaders: {

--- a/packages/node/src/http.ts
+++ b/packages/node/src/http.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import https from 'https';
 import process from 'process';
 
-import { Event, HttpRequest, Plugin } from '@envyjs/core';
+import { Event, HttpRequest, HttpRequestState, Plugin } from '@envyjs/core';
 
 // eslint thinks zlib is node20:builtin, but this is a node module
 // eslint-disable-next-line import/order
@@ -39,6 +39,7 @@ export const Http: Plugin = (_options, exporter) => {
           id,
           timestamp: startTs,
           http: {
+            state: HttpRequestState.Sent,
             requestHeaders,
             host: request.host,
             path: request.path,
@@ -130,6 +131,7 @@ export const Http: Plugin = (_options, exporter) => {
 
               http: {
                 ...httpRequest.http!,
+                state: HttpRequestState.Received,
                 httpVersion: response.httpVersion,
                 responseBody: undefined,
                 responseHeaders: response.headers,

--- a/packages/webui/src/collector/CollectorClient.test.ts
+++ b/packages/webui/src/collector/CollectorClient.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_WEB_SOCKET_PORT } from '@envyjs/core';
+import { DEFAULT_WEB_SOCKET_PORT, HttpRequestState } from '@envyjs/core';
 import { Server } from 'mock-socket';
 
 import { Trace } from '@/types';
@@ -15,6 +15,7 @@ describe('CollectorClient', () => {
       parentId: undefined,
       timestamp: 0,
       http: {
+        state: HttpRequestState.Sent,
         httpVersion: '1.1',
         method: 'GET',
         host: 'www.example.com',

--- a/packages/webui/src/components/ui/TraceDetail.test.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.test.tsx
@@ -1,3 +1,4 @@
+import { HttpRequestState } from '@envyjs/core';
 import { act, cleanup, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -615,6 +616,7 @@ describe('TraceDetail', () => {
           ...mockTrace,
           http: {
             ...mockTrace.http,
+            state: HttpRequestState.Sent,
             statusCode: undefined,
             statusMessage: undefined,
             responseHeaders: undefined,
@@ -768,6 +770,7 @@ describe('TraceDetail', () => {
         timestamp: Date.now(),
         http: {
           ...mockTrace.http,
+          state: HttpRequestState.Sent,
           statusCode: undefined,
           statusMessage: undefined,
           responseHeaders: undefined,

--- a/packages/webui/src/components/ui/TraceDetail.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.tsx
@@ -1,3 +1,4 @@
+import { HttpRequestState } from '@envyjs/core';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { Code, DateTime, Field, Fields, JsonDisplay, Loading, Section, XmlDisplay } from '@/components';
@@ -48,9 +49,9 @@ export default function TraceDetail({ className }: DetailProps) {
   const trace = getSelectedTrace();
 
   const { http, serviceName, timestamp } = trace || {};
-  const { method, host, url, requestHeaders, statusCode, statusMessage, responseHeaders, duration } = http || {};
+  const { method, host, url, requestHeaders, statusCode, statusMessage, responseHeaders, duration, state } = http || {};
 
-  const responseComplete = duration !== undefined && statusCode !== undefined;
+  const responseComplete = state !== HttpRequestState.Sent;
 
   const updateTimer = useCallback(() => {
     if (counterElRef.current) {
@@ -112,7 +113,7 @@ export default function TraceDetail({ className }: DetailProps) {
                 <span data-test-id="method" className="font-bold">
                   {method}
                 </span>
-                {responseComplete && (
+                {responseComplete && statusCode && (
                   <span data-test-id="status" className="flex items-center gap-2">
                     <span className={statusCodeStyle(statusCode)}></span>
                     {`${statusCode} ${statusMessage}`}
@@ -154,7 +155,7 @@ export default function TraceDetail({ className }: DetailProps) {
       </Section>
 
       <Section data-test-id="response-details" title="Response details">
-        {responseComplete ? (
+        {responseComplete && duration ? (
           <>
             <Fields data-test-id="response-fields">
               <Field data-test-id="received" label="Received">

--- a/packages/webui/src/testing/mockTraces.ts
+++ b/packages/webui/src/testing/mockTraces.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from '@envyjs/core';
+import { HttpRequest, HttpRequestState } from '@envyjs/core';
 
 import { Trace } from '@/types';
 
@@ -14,11 +14,12 @@ function requestData(
   host: HttpRequest['host'],
   port: HttpRequest['port'],
   path: HttpRequest['path'],
-): Pick<HttpRequest, 'method' | 'host' | 'port' | 'path' | 'url'> {
+): Pick<HttpRequest, 'method' | 'host' | 'port' | 'path' | 'url' | 'state'> {
   const protocol = port === 433 ? 'https://' : 'http://';
   const hostString = port === 80 || port === 443 ? `${host}` : `${host}:${port.toString()}`;
 
   return {
+    state: HttpRequestState.Sent,
     method,
     host,
     port,
@@ -36,6 +37,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(0),
     http: {
       ...requestData('GET', 'auth.restserver.com', 443, '/auth?client=mock_client'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'Authorization': ['Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
         'Content-Type': ['application/x-www-form-urlencoded'],
@@ -85,6 +87,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(0.1),
     http: {
       ...requestData('POST', 'localhost', 3000, '/api/graphql'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'authorization':
           'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vqb33-7FqzFWPNlr0ElW1v2RjJRZBel3CdDHBWD7y_o',
@@ -135,6 +138,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(1.2),
     http: {
       ...requestData('GET', 'data.restserver.com', 443, '/features'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'accept': 'application/json',
         'User-Agent': ['node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'],
@@ -177,6 +181,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(3.1),
     http: {
       ...requestData('GET', 'data.restserver.com', 443, '/countries?start=0&count=20'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'accept': 'application/json',
         'User-Agent': ['node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'],
@@ -216,6 +221,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(16.3),
     http: {
       ...requestData('POST', 'data.restserver.com', 443, '/people'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'authorization':
           'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vqb33-7FqzFWPNlr0ElW1v2RjJRZBel3CdDHBWD7y_o',
@@ -268,6 +274,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(0.1),
     http: {
       ...requestData('POST', 'localhost', 3000, '/api/graphql'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'authorization':
           'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.vqb33-7FqzFWPNlr0ElW1v2RjJRZBel3CdDHBWD7y_o',
@@ -319,6 +326,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(3.14),
     http: {
       ...requestData('GET', 'data.restserver.com', 433, '/movies?start=0&count=20'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'accept': 'application/json',
         'User-Agent': ['node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'],
@@ -358,6 +366,7 @@ const mockTraces: Trace[] = [
     timestamp: elapseTime(3.14),
     http: {
       ...requestData('GET', 'hits.webstats.com', 433, '/?apikey=c82e66bd-4d5b-4bb7-b439-896936c94eb2'),
+      state: HttpRequestState.Received,
       requestHeaders: {
         'accept': 'application/json',
         'User-Agent': ['node-fetch/1.0 (+https://github.com/bitinn/node-fetch)'],

--- a/packages/webui/src/utils/utils.test.ts
+++ b/packages/webui/src/utils/utils.test.ts
@@ -1,3 +1,4 @@
+import { HttpRequestState } from '@envyjs/core';
 import { twMerge } from 'tailwind-merge';
 
 import { Trace } from '@/types';
@@ -14,6 +15,7 @@ describe('utils', () => {
         parentId: undefined,
         timestamp: 0,
         http: {
+          state: HttpRequestState.Sent,
           httpVersion: '1.1',
           method: 'GET',
           host: 'www.example.com',


### PR DESCRIPTION
Adds an HTTP Request state for internal tracking.

Requests always begin in the `Sent` state. A request is then terminated in one the following ways:

```
Received: A response has been received from the server, regardless of HTTP status code (1xx/2xx/3xx/4xx/5xx)
Aborted: The request was aborted by the calling code (Applies to Fetch requests)
Blocked: The client blocked this via CORS policy
Timeout: The request timed out and no response was received
Error: There was an HTTP transport error and no response was received, or the response was unexpected
```