### PR TITLE
Improve the url parsing when using relative URLs

### DIFF
--- a/.changeset/strong-pens-camp.md
+++ b/.changeset/strong-pens-camp.md
@@ -1,0 +1,7 @@
+---
+'@envyjs/core': patch
+'@envyjs/node': patch
+'@envyjs/web': patch
+---
+
+Improve url parsing when using relative URLs

--- a/examples/next/utils/query.ts
+++ b/examples/next/utils/query.ts
@@ -1,15 +1,11 @@
 import { CatFact, Cocktail, Dog } from './types';
 
 export async function fetchCatFact(): Promise<CatFact> {
-  const res = await fetch('https://cat-fact.herokuapp.com/facts');
+  const res = await fetch('https://catfact.ninja/fact');
   const data = await res.json();
-  const allFacts = data.map((fact: CatFact) => ({
-    id: fact._id,
-    text: fact.text,
-  }));
-
-  const randomIdx = Math.floor(Math.random() * allFacts.length);
-  return allFacts[randomIdx];
+  return {
+    text: data.fact,
+  };
 }
 
 export async function fetchRandomCocktail(): Promise<Cocktail> {

--- a/examples/next/utils/types.ts
+++ b/examples/next/utils/types.ts
@@ -1,4 +1,4 @@
-export type CatFact = { _id: string; text: string };
+export type CatFact = { text: string };
 export type Cocktail = {
   id: string;
   name: string;

--- a/packages/core/src/fetch.test.ts
+++ b/packages/core/src/fetch.test.ts
@@ -25,7 +25,7 @@ describe('fetch', () => {
           url: 'http://localhost/api/path',
         },
         id: '1',
-        timestamp: 1698814800000,
+        timestamp: expect.any(Number),
       });
     });
 
@@ -42,7 +42,7 @@ describe('fetch', () => {
           url: 'http://localhost:5671/api/path',
         },
         id: '1',
-        timestamp: 1698814800000,
+        timestamp: expect.any(Number),
       });
     });
 
@@ -69,7 +69,7 @@ describe('fetch', () => {
           url: 'http://localhost/api/path',
         },
         id: '1',
-        timestamp: 1698814800000,
+        timestamp: expect.any(Number),
       });
     });
 
@@ -91,7 +91,7 @@ describe('fetch', () => {
           url: 'http://localhost/api/path',
         },
         id: '1',
-        timestamp: 1698814800000,
+        timestamp: expect.any(Number),
       });
     });
   });
@@ -127,7 +127,7 @@ describe('fetch', () => {
         },
         id: '1',
         parentId: undefined,
-        timestamp: 1698814800000,
+        timestamp: expect.any(Number),
       });
     });
   });

--- a/packages/core/src/fetch.test.ts
+++ b/packages/core/src/fetch.test.ts
@@ -100,15 +100,12 @@ describe('fetch', () => {
     it('should map a fetch response', async () => {
       const request = getEventFromFetchRequest('1', 'http://localhost/api/path');
       const response = await getEventFromFetchResponse(request, {
-        headers: new Headers({ key: 'value' }),
-        ok: true,
-        redirected: false,
+        headers: new MockHeaders({ key: 'value' }),
         status: 200,
         statusText: 'OK',
         type: 'default',
-        url: 'http://localhost/api/path',
         text: () => Promise.resolve('test'),
-      } as Response);
+      });
 
       expect(response).toEqual({
         http: {
@@ -137,7 +134,7 @@ describe('fetch', () => {
 
   describe('getUrlFromFetchRequest', () => {
     it('should parse a Request type', () => {
-      const info = new Request('http://localhost/api/path');
+      const info = new MockRequest('http://localhost/api/path');
       expect(getUrlFromFetchRequest(info)?.href).toEqual('http://localhost/api/path');
     });
 
@@ -201,7 +198,7 @@ describe('fetch', () => {
 
     it('should map header object', () => {
       const headers = parseFetchHeaders(
-        new Headers({
+        new MockHeaders({
           key: 'value',
           name: 'test',
         }),
@@ -214,3 +211,28 @@ describe('fetch', () => {
     });
   });
 });
+
+// mock the libdom Headers class
+class MockHeaders {
+  constructor(private values?: Record<string, string>) {}
+
+  *entries(): IterableIterator<[string, string]> {
+    for (const k in this.values) {
+      yield [k, this.values[k]];
+    }
+  }
+}
+
+// mock the libdom Request class
+class MockRequest {
+  constructor(private _url: string) {}
+  get headers(): MockHeaders {
+    return new MockHeaders();
+  }
+  get method(): string {
+    return 'get';
+  }
+  get url(): string {
+    return this._url;
+  }
+}

--- a/packages/core/src/fetch.test.ts
+++ b/packages/core/src/fetch.test.ts
@@ -1,0 +1,216 @@
+import {
+  getEventFromFetchRequest,
+  getEventFromFetchResponse,
+  getUrlFromFetchRequest,
+  parseFetchHeaders,
+} from './fetch';
+
+describe('fetch', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2023, 10, 1));
+  });
+
+  describe('getEventFromFetchRequest', () => {
+    it('should map a fetch request from a string url', () => {
+      const request = getEventFromFetchRequest('1', 'http://localhost/api/path');
+      expect(request).toEqual({
+        http: {
+          host: 'localhost',
+          method: 'GET',
+          path: '/api/path',
+          port: NaN,
+          requestHeaders: {},
+          state: 'sent',
+          url: 'http://localhost/api/path',
+        },
+        id: '1',
+        timestamp: 1698814800000,
+      });
+    });
+
+    it('should parse the host port number', () => {
+      const request = getEventFromFetchRequest('1', 'http://localhost:5671/api/path');
+      expect(request).toEqual({
+        http: {
+          host: 'localhost:5671',
+          method: 'GET',
+          path: '/api/path',
+          port: 5671,
+          requestHeaders: {},
+          state: 'sent',
+          url: 'http://localhost:5671/api/path',
+        },
+        id: '1',
+        timestamp: 1698814800000,
+      });
+    });
+
+    it('should map the fetch request headers', () => {
+      const init: RequestInit = {
+        headers: {
+          'x-array': 'value1',
+          'x-key': 'key1',
+        },
+      };
+
+      const request = getEventFromFetchRequest('1', 'http://localhost/api/path', init);
+      expect(request).toEqual({
+        http: {
+          host: 'localhost',
+          method: 'GET',
+          path: '/api/path',
+          port: NaN,
+          requestHeaders: {
+            'x-array': 'value1',
+            'x-key': 'key1',
+          },
+          state: 'sent',
+          url: 'http://localhost/api/path',
+        },
+        id: '1',
+        timestamp: 1698814800000,
+      });
+    });
+
+    it('should map the fetch request body', () => {
+      const init: RequestInit = {
+        body: new URLSearchParams('key=value&name=test'),
+      };
+
+      const request = getEventFromFetchRequest('1', 'http://localhost/api/path', init);
+      expect(request).toEqual({
+        http: {
+          host: 'localhost',
+          method: 'GET',
+          path: '/api/path',
+          port: NaN,
+          requestHeaders: {},
+          requestBody: 'key=value&name=test',
+          state: 'sent',
+          url: 'http://localhost/api/path',
+        },
+        id: '1',
+        timestamp: 1698814800000,
+      });
+    });
+  });
+
+  describe('getEventFromFetchRequest', () => {
+    it('should map a fetch response', async () => {
+      const request = getEventFromFetchRequest('1', 'http://localhost/api/path');
+      const response = await getEventFromFetchResponse(request, {
+        headers: new Headers({ key: 'value' }),
+        ok: true,
+        redirected: false,
+        status: 200,
+        statusText: 'OK',
+        type: 'default',
+        url: 'http://localhost/api/path',
+        text: () => Promise.resolve('test'),
+      } as Response);
+
+      expect(response).toEqual({
+        http: {
+          host: 'localhost',
+          httpVersion: 'default',
+          method: 'GET',
+          path: '/api/path',
+          port: NaN,
+          requestBody: undefined,
+          requestHeaders: {},
+          responseBody: 'test',
+          responseHeaders: {
+            key: 'value',
+          },
+          state: 'received',
+          statusCode: 200,
+          statusMessage: 'OK',
+          url: 'http://localhost/api/path',
+        },
+        id: '1',
+        parentId: undefined,
+        timestamp: 1698814800000,
+      });
+    });
+  });
+
+  describe('getUrlFromFetchRequest', () => {
+    it('should parse a Request type', () => {
+      const info = new Request('http://localhost/api/path');
+      expect(getUrlFromFetchRequest(info)?.href).toEqual('http://localhost/api/path');
+    });
+
+    it('should parse a URL type', () => {
+      const info = new URL('http://localhost/web');
+      expect(getUrlFromFetchRequest(info)?.href).toEqual('http://localhost/web');
+    });
+
+    it('should parse a fully qualified string type', () => {
+      const info = 'http://localhost/api/path';
+      expect(getUrlFromFetchRequest(info)?.href).toEqual('http://localhost/api/path');
+    });
+
+    it('should return a default for unqualified relative urls', () => {
+      const info = '/api/path';
+      expect(getUrlFromFetchRequest(info)?.href).toBe('http://localhost/');
+    });
+
+    describe('jsDom', () => {
+      beforeAll(() => {
+        globalThis.location = {
+          origin: 'http://localhost:2700',
+        } as any;
+      });
+
+      afterAll(() => {
+        globalThis.location = {} as any;
+      });
+
+      it('should parse a relative url when window is set', () => {
+        const info = '/api/path';
+        expect(getUrlFromFetchRequest(info)?.href).toEqual('http://localhost:2700/api/path');
+      });
+    });
+  });
+
+  describe('parseFetchHeaders', () => {
+    it('should map header value pairs', () => {
+      const headers = parseFetchHeaders([
+        ['key', 'value'],
+        ['name', 'test'],
+      ]);
+
+      expect(headers).toEqual({
+        key: 'value',
+        name: 'test',
+      });
+    });
+
+    it('should map header record', () => {
+      const headers = parseFetchHeaders({
+        key: 'value',
+        name: 'test',
+      });
+
+      expect(headers).toEqual({
+        key: 'value',
+        name: 'test',
+      });
+    });
+
+    it('should map header object', () => {
+      const headers = parseFetchHeaders(
+        new Headers({
+          key: 'value',
+          name: 'test',
+        }),
+      );
+
+      expect(headers).toEqual({
+        key: 'value',
+        name: 'test',
+      });
+    });
+  });
+});

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -1,10 +1,75 @@
 import { Event } from './event';
 import { HttpRequest, HttpRequestState } from './http';
+import { tryParseURL } from './url';
 
 // TODO: the types in this file are from lib/dom
 // we need to replace them with a platform agnostic version
 
-function formatFetchHeaders(headers: HeadersInit | Headers | undefined): HttpRequest['requestHeaders'] {
+/**
+ * Returns an {@link Event} from fetch request arguments
+ */
+export function getEventFromFetchRequest(id: string, input: RequestInfo | URL, init?: RequestInit): Event {
+  const url = getUrlFromFetchRequest(input);
+
+  return {
+    id,
+    parentId: undefined,
+    timestamp: Date.now(),
+    http: {
+      state: HttpRequestState.Sent,
+      method: (init?.method ?? 'GET') as HttpRequest['method'],
+      host: url.host,
+      port: parseInt(url.port, 10),
+      path: url.pathname,
+      url: url.toString(),
+      requestHeaders: parseFetchHeaders(init?.headers),
+      requestBody: init?.body?.toString() ?? undefined,
+    },
+  };
+}
+
+/**
+ * Returns an {@link Event} from a fetch response
+ */
+export async function getEventFromFetchResponse(req: Event, response: Response): Promise<Event> {
+  return {
+    ...req,
+
+    http: {
+      ...req.http!,
+      state: HttpRequestState.Received,
+      httpVersion: response.type,
+      statusCode: response.status,
+      statusMessage: response.statusText,
+      responseHeaders: parseFetchHeaders(response.headers),
+      responseBody: await response.text(),
+    },
+  };
+}
+
+/**
+ * Returns a {@link URL} from fetch request arguments.
+ * Fallback to localhost if the fetch arguments could not be parsed.
+ */
+export function getUrlFromFetchRequest(input: RequestInfo | URL): URL {
+  if (input instanceof URL) {
+    return input;
+  }
+
+  const url = input instanceof Request ? input.url : input;
+
+  // parse absolute and relative urls
+  const parsedUrl = tryParseURL(url) || tryParseURL(url, globalThis?.location?.origin);
+  if (parsedUrl) {
+    return parsedUrl;
+  }
+
+  // this library is for instrumentation, so we use a fallback
+  // to prevent throwing errors in consumer applications
+  return new URL('http://localhost/');
+}
+
+export function parseFetchHeaders(headers?: HeadersInit): HttpRequest['requestHeaders'] {
   if (headers) {
     if (Array.isArray(headers)) {
       return headers.reduce<HttpRequest['requestHeaders']>((acc, [key, value]) => {
@@ -19,47 +84,4 @@ function formatFetchHeaders(headers: HeadersInit | Headers | undefined): HttpReq
   }
 
   return {};
-}
-
-export function fetchRequestToEvent(id: string, input: RequestInfo | URL, init?: RequestInit): Event {
-  let url: URL;
-  if (typeof input === 'string') {
-    url = new URL(input);
-  } else if (input instanceof Request) {
-    url = new URL(input.url);
-  } else {
-    url = input;
-  }
-
-  return {
-    id,
-    parentId: undefined,
-    timestamp: Date.now(),
-    http: {
-      state: HttpRequestState.Sent,
-      method: (init?.method ?? 'GET') as HttpRequest['method'],
-      host: url.host,
-      port: parseInt(url.port, 10),
-      path: url.pathname,
-      url: url.toString(),
-      requestHeaders: formatFetchHeaders(init?.headers),
-      requestBody: init?.body?.toString() ?? undefined,
-    },
-  };
-}
-
-export async function fetchResponseToEvent(req: Event, response: Response): Promise<Event> {
-  return {
-    ...req,
-
-    http: {
-      ...req.http!,
-      state: HttpRequestState.Received,
-      httpVersion: response.type,
-      statusCode: response.status,
-      statusMessage: response.statusText,
-      responseHeaders: formatFetchHeaders(response.headers),
-      responseBody: await response.text(),
-    },
-  };
 }

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -1,9 +1,7 @@
 import { Event } from './event';
+import { HeadersInit, RequestInfo, RequestInit, Response } from './fetchTypes';
 import { HttpRequest, HttpRequestState } from './http';
 import { tryParseURL } from './url';
-
-// TODO: the types in this file are from lib/dom
-// we need to replace them with a platform agnostic version
 
 /**
  * Returns an {@link Event} from fetch request arguments
@@ -56,7 +54,7 @@ export function getUrlFromFetchRequest(input: RequestInfo | URL): URL {
     return input;
   }
 
-  const url = input instanceof Request ? input.url : input;
+  const url = (input as any).url ? (input as any).url : input;
 
   // parse absolute and relative urls
   const parsedUrl = tryParseURL(url) || tryParseURL(url, globalThis?.location?.origin);
@@ -76,10 +74,10 @@ export function parseFetchHeaders(headers?: HeadersInit): HttpRequest['requestHe
         acc[key] = value;
         return acc;
       }, {});
-    } else if (headers instanceof Headers) {
+    } else if (typeof headers.entries === 'function') {
       return Object.fromEntries(headers.entries());
     } else {
-      return headers;
+      return headers as Record<string, string>;
     }
   }
 

--- a/packages/core/src/fetchTypes.ts
+++ b/packages/core/src/fetchTypes.ts
@@ -1,0 +1,31 @@
+// These types are subsets of the libDom,
+// for cross-compatibility with Node 17+ and browser
+interface Headers {
+  entries(): IterableIterator<[string, string]>;
+}
+
+export type HeadersInit = [string, string][] | Record<string, string> | Headers;
+
+interface Request {
+  readonly headers: Headers;
+  readonly method: string;
+  readonly url: string;
+}
+
+export type RequestInfo = Request | string;
+
+type BodyInit = ReadableStream | XMLHttpRequestBodyInit;
+
+export interface RequestInit {
+  body?: BodyInit | null;
+  headers?: HeadersInit;
+  method?: string;
+}
+
+export interface Response {
+  readonly headers: Headers;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType;
+  text: () => Promise<string>;
+}

--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -1,0 +1,15 @@
+import { tryParseURL } from './url';
+
+describe('url', () => {
+  const cases = [
+    ['/relative', undefined, undefined],
+    ['/relative', 'localhost:3001', undefined],
+    ['/relative', 'http://localhost:3001', 'http://localhost:3001/relative'],
+    ['http://localhost:3001/path', undefined, 'http://localhost:3001/path'],
+    [new URL('http://localhost:3001/another'), undefined, 'http://localhost:3001/another'],
+  ];
+
+  it.each(cases)('should tryparse', (url: any, base: any, expected: any) => {
+    expect(tryParseURL(url, base)?.href).toEqual(expected);
+  });
+});

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,0 +1,7 @@
+export function tryParseURL(url: string | URL, base?: string): URL | undefined {
+  // implement cross platform `URL.canParse` since this function
+  // only exists in the DOM and not in Node
+  try {
+    return new URL(url, base);
+  } catch {}
+}

--- a/packages/core/src/websocket.ts
+++ b/packages/core/src/websocket.ts
@@ -53,7 +53,7 @@ export function WebSocketClient(options: WebSocketClientOptions) {
     ws.onerror = function error(error) {
       // only log this on the first error
       if (retry.attempts === 0) {
-        if (error.message.includes('ECONNREFUSED')) {
+        if (error?.message?.includes('ECONNREFUSED')) {
           if (debug) {
             log.error('websocket server not found', socket);
           }

--- a/packages/node/src/fetch.ts
+++ b/packages/node/src/fetch.ts
@@ -1,4 +1,4 @@
-import { Plugin, fetchRequestToEvent, fetchResponseToEvent } from '@envyjs/core';
+import { Plugin, getEventFromFetchRequest, getEventFromFetchResponse } from '@envyjs/core';
 
 import { generateId } from './id';
 
@@ -9,13 +9,13 @@ export const Fetch: Plugin = (_options, exporter) => {
     const startTs = performance.now();
 
     // export the initial request data
-    const reqEvent = fetchRequestToEvent(id, ...args);
+    const reqEvent = getEventFromFetchRequest(id, ...args);
     exporter.send(reqEvent);
 
     // execute the actual request
     const response = await originalFetch(...args);
     const responseClone = response.clone();
-    const resEvent = await fetchResponseToEvent(reqEvent, responseClone);
+    const resEvent = await getEventFromFetchResponse(reqEvent, responseClone);
 
     resEvent.http!.duration = performance.now() - startTs;
 

--- a/packages/web/src/fetch.ts
+++ b/packages/web/src/fetch.ts
@@ -1,4 +1,4 @@
-import { Plugin, fetchRequestToEvent, fetchResponseToEvent } from '@envyjs/core';
+import { Plugin, getEventFromFetchRequest, getEventFromFetchResponse } from '@envyjs/core';
 
 import { generateId } from './id';
 import { calculateTiming } from './performance';
@@ -10,7 +10,7 @@ export const Fetch: Plugin = (_options, exporter) => {
     const startTs = performance.now();
 
     // export the initial request data
-    const reqEvent = fetchRequestToEvent(id, ...args);
+    const reqEvent = getEventFromFetchRequest(id, ...args);
     exporter.send(reqEvent);
 
     performance.mark(reqEvent.id, { detail: { type: 'start' } });
@@ -18,7 +18,7 @@ export const Fetch: Plugin = (_options, exporter) => {
     // execute the actual request
     const response = await originalFetch(...args);
     const responseClone = response.clone();
-    const resEvent = await fetchResponseToEvent(reqEvent, responseClone);
+    const resEvent = await getEventFromFetchResponse(reqEvent, responseClone);
 
     performance.mark(reqEvent.id, { detail: { type: 'end' } });
 


### PR DESCRIPTION
Refactor URL parsing so we can correctly handle relative URLs passed to fetch via the browser. Uses a localhost fallback so we don't crash the application. Improves testing by covering the `fetch.ts` file to 100%

Fixes #129 