### PR TITLE
Add dark mode theme switcher

### DIFF
--- a/.changeset/two-trees-hide.md
+++ b/.changeset/two-trees-hide.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Add dark mode theme switcher behind feature flag

--- a/packages/webui/src/components/DarkModeToggle.test.tsx
+++ b/packages/webui/src/components/DarkModeToggle.test.tsx
@@ -1,0 +1,32 @@
+import { act, cleanup, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DarkModeToggle from './DarkModeToggle';
+
+function isDarkModeOnRoot() {
+  return document.documentElement.classList.contains('dark');
+}
+
+describe('DarkModeToggle', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render without error', () => {
+    render(<DarkModeToggle />);
+  });
+
+  it('should toggle the class on the root element', async () => {
+    const isDarkMode = isDarkModeOnRoot();
+
+    const { getByRole } = render(<DarkModeToggle />);
+    const toggle = getByRole('toggle');
+
+    await act(async () => {
+      await userEvent.click(toggle);
+    });
+
+    const expectedDarkMode = isDarkModeOnRoot();
+    expect(expectedDarkMode).toEqual(!isDarkMode);
+  });
+});

--- a/packages/webui/src/components/DarkModeToggle.tsx
+++ b/packages/webui/src/components/DarkModeToggle.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+export default function DarkModeToggle() {
+  const initialTheme = localStorage.theme === 'dark';
+  const [useDarkMode, setUseDarkMode] = useState(initialTheme);
+
+  const handleCheckboxChange = () => {
+    const shouldSetDarkMode = !useDarkMode;
+
+    if (shouldSetDarkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.theme = 'dark';
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.theme = 'light';
+    }
+
+    setUseDarkMode(shouldSetDarkMode);
+  };
+
+  return (
+    <div className="flex flex-col justify-center ml-3">
+      <input
+        type="checkbox"
+        name="light-switch"
+        className="light-switch sr-only"
+        checked={useDarkMode}
+        onChange={handleCheckboxChange}
+      />
+      <label
+        className="relative cursor-pointer p-2"
+        htmlFor="light-switch"
+        onClick={handleCheckboxChange}
+        role="toggle"
+      >
+        <svg className="dark:hidden" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+          <path
+            className="fill-slate-300"
+            d="M7 0h2v2H7zM12.88 1.637l1.414 1.415-1.415 1.413-1.413-1.414zM14 7h2v2h-2zM12.95 14.433l-1.414-1.413 1.413-1.415 1.415 1.414zM7 14h2v2H7zM2.98 14.364l-1.413-1.415 1.414-1.414 1.414 1.415zM0 7h2v2H0zM3.05 1.706 4.463 3.12 3.05 4.535 1.636 3.12z"
+          />
+          <path className="fill-slate-400" d="M8 4C5.8 4 4 5.8 4 8s1.8 4 4 4 4-1.8 4-4-1.8-4-4-4Z" />
+        </svg>
+        <svg className="hidden dark:block" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+          <path
+            className="fill-slate-400"
+            d="M6.2 1C3.2 1.8 1 4.6 1 7.9 1 11.8 4.2 15 8.1 15c3.3 0 6-2.2 6.9-5.2C9.7 11.2 4.8 6.3 6.2 1Z"
+          />
+          <path
+            className="fill-slate-500"
+            d="M12.5 5a.625.625 0 0 1-.625-.625 1.252 1.252 0 0 0-1.25-1.25.625.625 0 1 1 0-1.25 1.252 1.252 0 0 0 1.25-1.25.625.625 0 1 1 1.25 0c.001.69.56 1.249 1.25 1.25a.625.625 0 1 1 0 1.25c-.69.001-1.249.56-1.25 1.25A.625.625 0 0 1 12.5 5Z"
+          />
+        </svg>
+        <span className="sr-only">Switch to light / dark version</span>
+      </label>
+    </div>
+  );
+}

--- a/packages/webui/src/components/ui/Header.tsx
+++ b/packages/webui/src/components/ui/Header.tsx
@@ -1,10 +1,14 @@
+import useFeatureFlags from '@/hooks/useFeatureFlags';
 import { tw } from '@/utils';
+
+import DarkModeToggle from '../DarkModeToggle';
 
 import ConnectionStatus from './ConnectionStatus';
 import DebugToolbar from './DebugToolbar';
 import FiltersAndActions from './FiltersAndActions';
 
 export default function Header({ className, children, ...props }: React.HTMLAttributes<HTMLElement>) {
+  const { enableThemeSwitcher } = useFeatureFlags();
   const isDebugMode = process.env.NODE_ENV === 'development';
 
   return (
@@ -27,6 +31,7 @@ export default function Header({ className, children, ...props }: React.HTMLAttr
       </span>
       <span className="flex-0 flex items-center ml-auto gap-2">
         {isDebugMode && <DebugToolbar />}
+        {enableThemeSwitcher && <DarkModeToggle />}
         <FiltersAndActions />
       </span>
     </header>

--- a/packages/webui/src/hooks/useFeatureFlags.ts
+++ b/packages/webui/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,5 @@
+export default function useFeatureFlags() {
+  return {
+    enableThemeSwitcher: false,
+  };
+}

--- a/packages/webui/src/index.html
+++ b/packages/webui/src/index.html
@@ -6,6 +6,19 @@
     <link rel="shortcut icon" type="image/png" href="favicon.png" />
     <link rel="stylesheet" href="styles/base.css" />
     <script type="module" src="index.js"></script>
+    <script>
+      // inline theme switcher to prevent FOUC
+      if (
+        localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+        localStorage.theme = 'dark';
+      } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.theme = 'light';
+      }
+    </script>
     <title>Envy</title>
   </head>
   <body>

--- a/packages/webui/tailwind.config.js
+++ b/packages/webui/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./src/index.html', './src/**/*.tsx'],
   theme: {
     extend: {


### PR DESCRIPTION
Adds a dark mode theme toggle that uses the browsers media setting for its initial value and allows the user to override. Based on the recommended approach from Tailwind docs.

This feature is hidden behind a feature flag and is disabled by default. This PR is intended to help move the theme work forward by breaking it into smaller commits since changing the theme will be a lot of changes in a single PR.

Dark Enabled
![image](https://github.com/FormidableLabs/envy/assets/1521394/386930b8-5fe2-4d45-a8b6-c5719b77474c)

Light Enabled
![image](https://github.com/FormidableLabs/envy/assets/1521394/54b585ec-da88-4d44-92ac-ed124564d8ec)


Closes #136