### PR TITLE
Cleanup requests that did not receive a response

### DIFF
--- a/.changeset/soft-shrimps-knock.md
+++ b/.changeset/soft-shrimps-knock.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Cleanup requests that did not receive a response

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -1,4 +1,4 @@
-import { ConnectionStatusData, DEFAULT_WEB_SOCKET_PORT, Event, WebSocketPayload, safeParseJson } from '@envyjs/core';
+import { ConnectionStatusData, DEFAULT_WEB_SOCKET_PORT, Event, HttpRequestState, WebSocketPayload, safeParseJson } from '@envyjs/core';
 
 import { Traces } from '@/types';
 
@@ -81,8 +81,8 @@ export default class CollectorClient {
   private _setHttpTimeout(id: string) {
     setTimeout(() => {
       const trace = this._traces.get(id);
-      if (trace.http.state === 'sent') {
-        trace.http.state = 'timeout';
+      if (trace?.http?.state === 'sent') {
+        trace.http.state = HttpRequestState.Timeout;
         trace.http.statusMessage = 'NO RESPONSE';
         trace.http.statusCode = 418;
         trace.http.duration = INTERNAL_HTTP_TIMEOUT;

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -118,7 +118,7 @@ export default class CollectorClient {
     if (isNewTrace && !!trace.http) {
       this._setHttpTimeout(trace.id);
     } else if (this._cleanup.has(trace.id)) {
-      clearTimeout(trace.id);
+      clearTimeout(this._cleanup.get(trace.id));
     }
 
     this._traces.set(trace.id, trace);

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -1,4 +1,11 @@
-import { ConnectionStatusData, DEFAULT_WEB_SOCKET_PORT, Event, HttpRequestState, WebSocketPayload, safeParseJson } from '@envyjs/core';
+import {
+  ConnectionStatusData,
+  DEFAULT_WEB_SOCKET_PORT,
+  Event,
+  HttpRequestState,
+  WebSocketPayload,
+  safeParseJson,
+} from '@envyjs/core';
 
 import { Traces } from '@/types';
 

--- a/packages/webui/src/collector/CollectorClient.ts
+++ b/packages/webui/src/collector/CollectorClient.ts
@@ -90,11 +90,10 @@ export default class CollectorClient {
       const trace = this._traces.get(id);
       if (trace?.http?.state === 'sent') {
         trace.http.state = HttpRequestState.Timeout;
-        trace.http.statusMessage = 'NO RESPONSE';
-        trace.http.statusCode = 418;
+        trace.http.statusMessage = 'TIMEOUT';
+        trace.http.statusCode = -1;
         trace.http.duration = INTERNAL_HTTP_TIMEOUT;
-        trace.http.responseBody =
-          'Envy did not receive a response in a timely manner. This does not neccessarily indicate there was a problem with the request.';
+        trace.http.responseBody = 'TIMEOUT WAITING FOR RESPONSE';
         this.addEvent(trace);
       }
     }, INTERNAL_HTTP_TIMEOUT);

--- a/packages/webui/src/components/ui/TraceDetail.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.tsx
@@ -85,6 +85,7 @@ export default function TraceDetail() {
     else if (code >= 400) style = 'bg-red-500';
     else if (code >= 300) style = 'bg-yellow-500';
     else if (code >= 200) style = 'bg-green-500';
+    else if (code === -1) style = 'bg-gray-500';
     return `inline-block rounded-full h-3 w-3 ${style}`;
   }
 
@@ -111,7 +112,7 @@ export default function TraceDetail() {
                 {responseComplete && statusCode && (
                   <span data-test-id="status" className="flex items-center gap-2">
                     <span className={statusCodeStyle(statusCode)}></span>
-                    {`${statusCode} ${statusMessage}`}
+                    {`${statusCode > -1 ? statusCode : ''} ${statusMessage}`}
                   </span>
                 )}
               </span>
@@ -157,7 +158,7 @@ export default function TraceDetail() {
                 <DateTime time={timestamp! + duration} />
               </Field>
               <Field data-test-id="status" label="Status">
-                {statusCode} {statusMessage}
+                {statusCode && statusCode > -1 ? statusCode : ''} {statusMessage}
               </Field>
               <ResponseHeaders data-test-id="headers" trace={trace} />
               <Field data-test-id="duration" label="Duration">

--- a/packages/webui/src/components/ui/TraceList.tsx
+++ b/packages/webui/src/components/ui/TraceList.tsx
@@ -16,7 +16,7 @@ function MethodAndStatus({ method, statusCode }: MethodAndStatusProps) {
   return (
     <>
       <span className="block">{method.toUpperCase()}</span>
-      <span className="block text-xs">{statusCode ?? '-'}</span>
+      <span className="block text-xs">{statusCode && statusCode > -1 ? statusCode : '-'}</span>
     </>
   );
 }


### PR DESCRIPTION
Cleanup requests that did not receive a response by setting the state to `TIMEOUT` and the HTTP Status to `-1`.

Since each browser implementation (Fetch, XMLHttp), and each browser (FF, Chrome, etc), and each platform (web, node) all use different timeouts, we choose an arbitrary timeout of 2mins. If the request still responds after that time, the UX will still update itself appropriately.

![image](https://github.com/FormidableLabs/envy/assets/1521394/44843a5f-ab39-4c48-8183-3c98ad19f31a)

