### PR TITLE
Use zlib node builtin

### DIFF
--- a/.changeset/famous-moles-move.md
+++ b/.changeset/famous-moles-move.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/node': patch
+---
+
+Use zlib node builtin

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,8 +21,7 @@
     "@envyjs/core": "0.7.1",
     "chalk": "^4.1.2",
     "shimmer": "^1.2.1",
-    "ws": "8.14.2",
-    "zlib": "1.0.5"
+    "ws": "8.14.2"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.6.4",

--- a/packages/node/src/http.ts
+++ b/packages/node/src/http.ts
@@ -1,12 +1,9 @@
 import http from 'http';
 import https from 'https';
 import process from 'process';
+import { createBrotliDecompress, unzip } from 'zlib';
 
 import { Event, HttpRequest, HttpRequestState, Plugin } from '@envyjs/core';
-
-// eslint thinks zlib is node20:builtin, but this is a node module
-// eslint-disable-next-line import/order
-import { createBrotliDecompress, unzip } from 'zlib';
 
 import { generateId } from './id';
 import log from './log';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13226,11 +13226,6 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zlib@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
-  integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==
-
 zod@3.21.4:
   version "3.21.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"


### PR DESCRIPTION
Removes zlib, we had this in there from when we tried to have a module that worked for both node+web, now this file is just in node it can use the zlib built into node itself