### PR TITLE
Add env flag to allow provenance publishing

### DIFF
--- a/.changeset/tiny-mangos-yawn.md
+++ b/.changeset/tiny-mangos-yawn.md
@@ -1,0 +1,10 @@
+---
+'@envyjs/apollo': patch
+'@envyjs/core': patch
+'@envyjs/nextjs': patch
+'@envyjs/node': patch
+'@envyjs/web': patch
+'@envyjs/webui': patch
+---
+
+Publish package provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [build]
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
NPM is not showing the provenance link for our packages. Set the env variable so NPM will set the flag in changesets/cli

Ref: https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools