### PR TITLE
Use repository directory fields for npm

### DIFF
--- a/.changeset/thin-sheep-hope.md
+++ b/.changeset/thin-sheep-hope.md
@@ -1,0 +1,10 @@
+---
+'@envyjs/apollo': patch
+'@envyjs/nextjs': patch
+'@envyjs/webui': patch
+'@envyjs/core': patch
+'@envyjs/node': patch
+'@envyjs/web': patch
+---
+
+Use repository directory fields for npm

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.1",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/apollo"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.1",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/core"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.1",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/nextjs"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.1",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/node"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,11 @@
   "version": "0.8.1",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/web"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -16,7 +16,11 @@
     "envy": "bin/start.cjs"
   },
   "type": "module",
-  "repository": "https://github.com/FormidableLabs/envy.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy.git",
+    "directory": "packages/webui"
+  },
   "license": "MIT",
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Use repository directory fields for npm so it can properly detect Provenance
