### PR TITLE
Add npm metadata to all packages

### DIFF
--- a/.changeset/wicked-moons-promise.md
+++ b/.changeset/wicked-moons-promise.md
@@ -1,0 +1,10 @@
+---
+'@envyjs/apollo': patch
+'@envyjs/nextjs': patch
+'@envyjs/webui': patch
+'@envyjs/core': patch
+'@envyjs/node': patch
+'@envyjs/web': patch
+---
+
+Add npm metadata to all packages

--- a/package.json
+++ b/package.json
@@ -2,12 +2,24 @@
   "name": "envy",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "index.js",
-  "repository": "https://github.com/FormidableLabs/envy.git",
-  "contributors": [
-    "Charlie Brown <carbonrobot@gmail.com>",
-    "Kevin Paxton <kevinpaxton82@gmail.com>",
-    "Matthew Ritter <matthewwilliamritter@gmail.com>"
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/envy"
+  },
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -3,9 +3,23 @@
   "version": "0.8.2",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/apollo"
   },
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,9 +3,23 @@
   "version": "0.8.2",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/core"
   },
   "license": "MIT",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -3,9 +3,23 @@
   "version": "0.8.2",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/nextjs"
   },
   "license": "MIT",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,9 +3,23 @@
   "version": "0.8.2",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/node"
   },
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,9 +3,23 @@
   "version": "0.8.2",
   "description": "Node.js Network & Telemetry Viewer",
   "main": "dist/index.js",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/web"
   },
   "license": "MIT",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -16,9 +16,23 @@
     "envy": "bin/start.cjs"
   },
   "type": "module",
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "homepage": "https://github.com/formidablelabs/envy",
+  "keywords": [
+    "react",
+    "nextjs",
+    "graphql",
+    "typescript",
+    "nodejs",
+    "telemetry",
+    "tracing"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy.git",
+    "url": "https://github.com/FormidableLabs/envy",
     "directory": "packages/webui"
   },
   "license": "MIT",


### PR DESCRIPTION
Add npm metadata to all packages

- Adds author and homepage
- Removes .git extension from url in hope that NPM picks this up correctly
- Removes the contributors block since that is now autocalculated by github. The collaborators list in NPM is a permissions list, so it also has no affects there either.