### PR TITLE
Fix npm publish warnings during install

### DIFF
--- a/.changeset/empty-pens-double.md
+++ b/.changeset/empty-pens-double.md
@@ -1,0 +1,10 @@
+---
+'@envyjs/apollo': patch
+'@envyjs/nextjs': patch
+'@envyjs/webui': patch
+'@envyjs/core': patch
+'@envyjs/node': patch
+'@envyjs/web': patch
+---
+
+Fix npm publish warnings about git syntax

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy"
+    "url": "git+https://github.com/FormidableLabs/envy.git"
   },
   "license": "MIT",
   "private": true,
@@ -65,7 +65,7 @@
     "wait-on": "^7.0.1"
   },
   "resolutions": {
-    "@microlink/react-json-view/react": "^17.0.0",
+    "@microlink/react-json-view/react": ">=17",
     "react-hot-toast/csstype": "^3.0.10"
   },
   "lint-staged": {

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/apollo"
   },
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/core"
   },
   "license": "MIT",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/nextjs"
   },
   "license": "MIT",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/node"
   },
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/web"
   },
   "license": "MIT",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/envy",
+    "url": "git+https://github.com/FormidableLabs/envy.git",
     "directory": "packages/webui"
   },
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11132,20 +11132,12 @@ react-textarea-autosize@~8.3.2:
     use-composed-ref "^1.3.0"
     use-latest "^1.2.1"
 
-react@18.2.0, react@^18.2.0:
+react@18.2.0, "react@>= 17", react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-
-react@^17.0.0:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-cache@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
When running npm publish locally, there is additional warnings from NPM. This fixes those warnings.
