### PR TITLE
Move react-json-view to peer dependency

### DIFF
--- a/.changeset/funny-buttons-think.md
+++ b/.changeset/funny-buttons-think.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Move react-json-view to peer dependency to avoid infinite loop in npm installs

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@envyjs/core": "0.8.3",
-    "@microlink/react-json-view": "^1.22.2",
     "chalk": "^4.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -72,6 +71,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@microlink/react-json-view": "^1.22.2",
     "@parcel/config-default": "^2.9.3",
     "@parcel/core": "^2.9.3",
     "@storybook/cli": "^7.4.6",
@@ -114,6 +114,9 @@
     "ts-jest": "^29.1.1",
     "ts-jest-mock-import-meta": "^1.1.0",
     "vite": "^4.4.9"
+  },
+  "peerDependencies": {
+    "@microlink/react-json-view": "^1.22.2"
   },
   "browserslist": [
     ">0.2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11132,7 +11132,7 @@ react-textarea-autosize@~8.3.2:
     use-composed-ref "^1.3.0"
     use-latest "^1.2.1"
 
-react@18.2.0, "react@>= 17", react@^18.2.0:
+react@18.2.0, react@>=17, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
Move `@microlink/react-json-view` to peer dependency. Reported by @yankovalera

### Bug

Installing with `npm>7.x` causes an infinite loop due to conflicting React peer deps in client projects
ref: https://github.com/npm/cli/issues/6611

### Background

npm > 7 now installs [peer dependencies by default](https://github.com/npm/rfcs/blob/main/implemented/0025-install-peer-deps.md) 

When running `npm i @envyjs/webui` in an demo repo, `npm` will automatically install peer dependencies and fail with an infinite loop. This is because `@microlink/react-json-view` has a dependency on `flux`, and `flux` has a peer dependency on React@17, while `envy` has a peer dependency on React@18. The current npm bug then prevents the install and crashes.

![image](https://github.com/FormidableLabs/envy/assets/1521394/056b9d0b-1e4b-47af-ac88-cd6b7560077b)

Locally, within the envy repo everything works as expected because we have a peer dependency resolution in our main `package.json` file.

### Change

This moves `@microlink/react-json-view` to a peer dependency which has the following effect

- When installed via `npm>7` and used in the default way, `@envyjs/webui` will work as expected
- When installed via `npm>7` and used as a custom viewer component, `@envyjs/webui` will work as expected
- When installed via `yarn/pnpm` and used in the default way, `@envyjs/webui` will work as expected
- When installed via `yarn/pnpm` and used as a custom viewer component, users will also need to install `@microlink/react-json-view` as a dependency, since `yarn/pnpm` do not install peer deps automatically

### Future

Many dependencies under `@microlink/react-json-view` are either deprecated or outdated. We should look into alternatives for json display. One possible replacement is the component we use in the `groqd`'s arcade... `monaco-editor`