### PR TITLE
Ensure selected row color takes precedence

### DIFF
--- a/.changeset/clean-beds-pull.md
+++ b/.changeset/clean-beds-pull.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Ensure selected row color takes precendence

--- a/packages/webui/src/components/ui/TraceListRow.tsx
+++ b/packages/webui/src/components/ui/TraceListRow.tsx
@@ -18,8 +18,9 @@ export default function TraceListRow({ trace }: { trace: Trace }) {
       key={trace.id}
       onClick={() => setSelectedTrace(trace.id)}
       className={tw(
-        'table-row h-11 hover:bg-apple-200 hover:cursor-pointer hover:text-apple-900 even:bg-manatee-200 text-manatee-800',
+        'table-row h-11 hover:bg-apple-200 hover:cursor-pointer hover:text-apple-900 text-manatee-800',
         trace.http?.state === HttpRequestState.Sent && 'text-manatee-500',
+        trace.id !== selectedTraceId && 'even:bg-manatee-200',
         trace.id === selectedTraceId && 'bg-manatee-400 text-manatee-950',
       )}
     >

--- a/packages/webui/src/components/ui/TraceListRow.tsx
+++ b/packages/webui/src/components/ui/TraceListRow.tsx
@@ -20,8 +20,7 @@ export default function TraceListRow({ trace }: { trace: Trace }) {
       className={tw(
         'table-row h-11 hover:bg-apple-200 hover:cursor-pointer hover:text-apple-900 text-manatee-800',
         trace.http?.state === HttpRequestState.Sent && 'text-manatee-500',
-        trace.id !== selectedTraceId && 'even:bg-manatee-200',
-        trace.id === selectedTraceId && 'bg-manatee-400 text-manatee-950',
+        trace.id === selectedTraceId ? 'bg-manatee-400 text-manatee-950' : 'even:bg-manatee-200',
       )}
     >
       <TraceListRowCell data-test-id="column-data-method-cell">


### PR DESCRIPTION
Fixes the selected row color on even rows. The `even:` modifier was overriding the selected row color.

Closes #184 