### PR TITLE
Various UI fixes

### DIFF
--- a/.changeset/dry-planes-know.md
+++ b/.changeset/dry-planes-know.md
@@ -1,0 +1,5 @@
+---
+'@envyjs/webui': patch
+---
+
+Minor UI tweaks

--- a/packages/webui/src/components/Authorization.tsx
+++ b/packages/webui/src/components/Authorization.tsx
@@ -72,7 +72,7 @@ export default function Authorization({ value }: AuthorizationProps) {
       decoded = JSON.stringify({ username: un, password: pw });
     }
 
-    setDecodedToken(<CodeDisplay contentType="application/json" data={decoded} />);
+    setDecodedToken(<CodeDisplay contentType="application/json" data={decoded} className="py-4" />);
   }
 
   return (
@@ -98,7 +98,7 @@ export default function Authorization({ value }: AuthorizationProps) {
             return <Code data-test-id="token-expanded-view">{`${type} ${token}`}</Code>;
           case TokenState.Decoded:
             return (
-              <div data-test-id="token-decoded-view" className="h-[200px]">
+              <div data-test-id="token-decoded-view" className="bg-manatee-100">
                 {decodedToken}
               </div>
             );

--- a/packages/webui/src/components/CodeDisplay.tsx
+++ b/packages/webui/src/components/CodeDisplay.tsx
@@ -1,11 +1,15 @@
 import { safeParseJson } from '@envyjs/core';
 import formatXml from 'xml-formatter';
 
-import Editor, { MonacoEditorProps } from './MonacoEditor';
+import { tw } from '@/utils';
+
+import Editor, { EditorHeight, MonacoEditorProps } from './MonacoEditor';
 
 type CodeDisplayProps = {
   contentType?: string | string[] | null;
   data: string | null | undefined;
+  editorHeight?: EditorHeight;
+  className?: string;
 };
 
 const languageMap: Record<string, MonacoEditorProps['language']> = {
@@ -14,7 +18,7 @@ const languageMap: Record<string, MonacoEditorProps['language']> = {
   'application/xml': 'xml',
 };
 
-export default function CodeDisplay({ data, contentType }: CodeDisplayProps) {
+export default function CodeDisplay({ data, contentType, editorHeight, className }: CodeDisplayProps) {
   if (!data) {
     return;
   }
@@ -42,8 +46,8 @@ export default function CodeDisplay({ data, contentType }: CodeDisplayProps) {
   }
 
   return (
-    <div className="w-full h-full">
-      <Editor value={value} language={lang} />
+    <div className={tw('w-full h-full', className)}>
+      <Editor value={value} language={lang} height={editorHeight} />
     </div>
   );
 }

--- a/packages/webui/src/components/Fields.tsx
+++ b/packages/webui/src/components/Fields.tsx
@@ -19,7 +19,7 @@ export default function Fields({ className, children, ...props }: FieldsProps) {
 export function Field({ label, className, children, ...props }: FieldProps) {
   if (!children) return null;
   return (
-    <tr className={className} {...props}>
+    <tr className={tw('align-top', className)} {...props}>
       <td className={tw('table-cell w-[200px] py-1 font-semibold font-mono uppercase', className)}>{label}</td>
       <td className="table-cell font-mono">{children}</td>
     </tr>

--- a/packages/webui/src/components/Section.tsx
+++ b/packages/webui/src/components/Section.tsx
@@ -27,7 +27,7 @@ export default function Section({ title, collapsible = true, className, children
           }}
           {...props}
         >
-          <div className="flex-1">{title}</div>
+          <div className={tw('flex-1', !expanded && 'opacity-50')}>{title}</div>
           {collapsible && <Icon className="h-6 w-6" />}
         </div>
       )}

--- a/packages/webui/src/components/ui/TraceDetail.test.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.test.tsx
@@ -31,7 +31,7 @@ jest.mock('@/components', () => ({
   Fields: function (props: any) {
     return <div {...props} />;
   },
-  CodeDisplay: function ({ children, contentType, ...props }: any) {
+  CodeDisplay: function ({ children, contentType, editorHeight, ...props }: any) {
     return (
       <div {...props} data-content-type={contentType}>
         Mock CodeDisplay component: {children}

--- a/packages/webui/src/components/ui/TraceDetail.tsx
+++ b/packages/webui/src/components/ui/TraceDetail.tsx
@@ -87,7 +87,7 @@ export default function TraceDetail() {
             <div className="flex items-center">
               <img src={getIconUri(trace)} alt="" className="w-6 h-6" />
             </div>
-            <div className="text-xl font-bold" data-test-id="method">
+            <div className="text-xl font-bold uppercase" data-test-id="method">
               {method}
             </div>
             {requestAborted && (
@@ -203,6 +203,7 @@ export default function TraceDetail() {
             data-test-id="request-body"
             contentType={getHeader(requestHeaders, 'content-type')}
             data={requestBody}
+            editorHeight="full"
           />
         </TabContent>
 
@@ -212,6 +213,7 @@ export default function TraceDetail() {
               data-test-id="response-body"
               contentType={getHeader(responseHeaders, 'content-type')}
               data={responseBody}
+              editorHeight="full"
             />
           )}
         </TabContent>

--- a/packages/webui/src/styles/base.css
+++ b/packages/webui/src/styles/base.css
@@ -90,7 +90,6 @@ input[type='search']::-webkit-search-results-decoration {
 .code-block > ul > li {
   @apply px-4;
   @apply whitespace-pre-wrap;
-  @apply hover:bg-opacity-50 hover:bg-white;
   @apply hover:cursor-default;
 }
 
@@ -98,21 +97,21 @@ input[type='search']::-webkit-search-results-decoration {
  * Tables
  */
 .badge-200 {
-  @apply bg-[#318B47] text-white
+  @apply bg-[#318B47] text-white;
 }
 
 .badge-300 {
-  @apply bg-yellow-400 text-white
+  @apply bg-yellow-400 text-white;
 }
 
 .badge-400 {
-  @apply bg-[#AC0535] text-white
+  @apply bg-[#AC0535] text-white;
 }
 
 .badge-500 {
-  @apply bg-[#613C8D] text-white
+  @apply bg-[#613C8D] text-white;
 }
 
 .badge-abort {
-  @apply bg-manatee-700 text-white
+  @apply bg-manatee-700 text-white;
 }

--- a/packages/webui/src/systems/GraphQL.tsx
+++ b/packages/webui/src/systems/GraphQL.tsx
@@ -49,19 +49,17 @@ export default class GraphQLSystem implements System<GraphQLData> {
     const { operationType, operationName, query } = data;
 
     return (
-      <div className="border-t border-manatee-400 pt-3 mt-3">
-        <Fields>
-          <Field data-test-id="name" label="Name">
-            {operationName}
-          </Field>
-          <Field data-test-id="type" label="Type">
-            {operationType}
-          </Field>
-          <Field label="Query">
-            <Code data-test-id="query">{query}</Code>
-          </Field>
-        </Fields>
-      </div>
+      <Fields>
+        <Field data-test-id="name" label="Name">
+          {operationName}
+        </Field>
+        <Field data-test-id="type" label="Type">
+          {operationType}
+        </Field>
+        <Field label="Query">
+          <Code data-test-id="query">{query}</Code>
+        </Field>
+      </Fields>
     );
   }
 }

--- a/packages/webui/src/systems/Sanity.tsx
+++ b/packages/webui/src/systems/Sanity.tsx
@@ -48,16 +48,14 @@ export default class SanitySystem implements System<SanityData> {
     const { type, query } = data;
 
     return (
-      <div className="border-t border-manatee-400 pt-3 mt-3">
-        <Fields>
-          <Field data-test-id="type" label="Item type">
-            {type}
-          </Field>
-          <Field label="Query">
-            <Code data-test-id="query">{query}</Code>
-          </Field>
-        </Fields>
-      </div>
+      <Fields>
+        <Field data-test-id="type" label="Item type">
+          {type}
+        </Field>
+        <Field label="Query">
+          <Code data-test-id="query">{query}</Code>
+        </Field>
+      </Fields>
     );
   }
 

--- a/packages/webui/src/systems/index.tsx
+++ b/packages/webui/src/systems/index.tsx
@@ -64,10 +64,10 @@ export function ListDataComponent({ trace }: SystemDetailProps): React.ReactNode
 
 export function RequestDetailsComponent({ trace }: SystemDetailProps): React.ReactNode {
   const Component = callOrFallback<ReactNode | null>(trace, 'getRequestDetailComponent');
-  return Component ? Component : null;
+  return Component ? <div className="border-t border-manatee-200 pt-4 mt-4">{Component}</div> : null;
 }
 
 export function ResponseDetailsComponent({ trace }: SystemDetailProps): React.ReactNode {
   const Component = callOrFallback<ReactNode | null>(trace, 'getResponseDetailComponent');
-  return Component ? Component : null;
+  return Component ? <div className="border-t border-manatee-200 pt-4 mt-4">{Component}</div> : null;
 }


### PR DESCRIPTION
## What does this PR do

Makes various UI tweaks and fixes based on observations using Envy:

### Ensure capitalised HTTP verb

Some applications had the HTTP verb (`GET`, `POST`, etc) in lowercase, and nothing was ensuring uppercase presentation in the trace details UI, so I've set this to always be uppercase now.

| Before | After (fix) |
| --- | --- |
| ![image](https://github.com/FormidableLabs/envy/assets/17857833/4a2970f4-d2d8-4714-8b27-de7ee39c6596) | ![image](https://github.com/FormidableLabs/envy/assets/17857833/c9732f2d-adaf-4e74-82b7-3e1fdde22412) |

### Vertically align field names

When writing custom systems with custom request or response details using the `<Field>` component, any usage which had a multi-line value would mean that the field label would be centre-aligned, rather than top-aligned.

| Before | After (fix) |
| --- | --- |
| ![image](https://github.com/FormidableLabs/envy/assets/17857833/f8b65314-8a75-484e-b80d-9963fdf480e2) | ![image](https://github.com/FormidableLabs/envy/assets/17857833/24379941-6e3a-46e8-bb86-132eb1149a97) |

### Tweaks to inline Monaco code editor

When the Monaco code editor was used to display the decoded authorization header value, it had a couple of problems:
- It had a fixed height of 200px, regardless of actual content
- It didn't match the background of the heading of the component

| Before | After (fix) |
| --- | --- |
| ![image](https://github.com/FormidableLabs/envy/assets/17857833/7ec5321f-afb9-432d-94ff-97964459304e) | ![image](https://github.com/FormidableLabs/envy/assets/17857833/2c117585-ea5e-4bc9-8405-80c156669256) |

### Collapsed sections made slightly more obvious

When collapsing a section of the trace details, the content would be hidden but it was not abundantly clear that the section was in the collapsed state.  I've now made the text have a 50% opacity, which gives a better visual indication that the section is collapsed.

| Before | After (fix) |
| --- | --- |
| ![image](https://github.com/FormidableLabs/envy/assets/17857833/b3ed51f1-654e-419d-b702-fab4f336fef8) | ![image](https://github.com/FormidableLabs/envy/assets/17857833/a2b79ead-d215-4509-9392-a73cfde5c394) |

### Automatic divider between built-in and custom request or response detail components

Previously, any custom components defined by a system would have no separation from the built-in details in those sections, and authors of those components would need to add in the divider/separation into the UI.

Now, this is done automatically, meaning that custom systems can just supply the component with no divider or padding required.

![image](https://github.com/FormidableLabs/envy/assets/17857833/c1d68702-43e8-45ee-b277-ce4c32320ee9)